### PR TITLE
Support for ARMv7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,6 @@ jobs:
           file: ./${{ matrix.meta.entries[0].directory }}/Dockerfile
           push: true
           tags: ${{ steps.modify_tags.outputs.modified_tags }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           provenance: false
           load: false


### PR DESCRIPTION
This *modern* 32bit arch can still be considered quite widely used in old Raspberry Pi and other cheap development boards.