### PR TITLE
Enabling schedule to build unstable images nightly.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - '**/Dockerfile*'
   schedule:
-    - cron: 0 0 * * 0
+    - cron: '0 0 * * *'
 
 defaults:
   run:
@@ -26,6 +26,11 @@ jobs:
         name: Generate Jobs
         run: |
           strategy="$("$BASHBREW_SCRIPTS/github-actions/generate.sh")"
+          # If triggered by a cron event, filter strategy to include `unstable` and `unstable-alpine`
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            strategy=$(jq -c '{"fail-fast": .["fail-fast"],"matrix":{"include":[ .matrix.include[]|select(.name =="unstable" or .name== "unstable-alpine")]}}' <<<"$strategy")
+          fi
+
           echo "strategy=$strategy" >> "$GITHUB_OUTPUT"
           jq . <<<"$strategy" # sanity check / debugging aid
 
@@ -51,7 +56,7 @@ jobs:
 
   build_and_push:
     if: |
-      (github.event_name == 'push' && 
+      ((github.event_name == 'push' || github.event_name == 'schedule') && 
       github.ref == 'refs/heads/mainline')
     needs: 
       - generate-jobs
@@ -91,3 +96,13 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           provenance: false
           load: false
+
+  update-dockerhub-description:
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/mainline')
+    needs: 
+      - generate-jobs
+      - test
+      - build_and_push
+    name: Update DockerHub Description
+    uses: ./.github/workflows/update-dockerhub-docs.yml

--- a/.github/workflows/update-dockerhub-docs.yml
+++ b/.github/workflows/update-dockerhub-docs.yml
@@ -2,10 +2,7 @@ name: Update Dockerhub description
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: [GitHub CI]
-    types: [completed]
-    branches: [mainline]
+  workflow_call:
 
 jobs:
   update-dockerhub:
@@ -15,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v4
         with:


### PR DESCRIPTION
Resolves #29 

Here for scheduled event type(nightly), we will filter the unstable and unstable-alpine strategy to run tests, build and publish the images nightly.

Also changes some logic to call update-dockethub-description only for new builds and avoid running it every day.

The image tagging will be done branch-wise, that is, the image tag for nightly build will be unstable and unstable-alpine and these will follow the unstable branch on the main project repo.