### PR TITLE
fixes update-dockerhub-docs.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,3 +106,7 @@ jobs:
       - build_and_push
     name: Update DockerHub Description
     uses: ./.github/workflows/update-dockerhub-docs.yml
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      DOCKERHUB_REPOSITORY: ${{ secrets.DOCKERHUB_REPOSITORY }}

--- a/.github/workflows/update-dockerhub-docs.yml
+++ b/.github/workflows/update-dockerhub-docs.yml
@@ -3,6 +3,13 @@ name: Update Dockerhub description
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+      DOCKERHUB_REPOSITORY:
+        required: true
 
 jobs:
   update-dockerhub:

--- a/8.0/alpine/Dockerfile
+++ b/8.0/alpine/Dockerfile
@@ -21,9 +21,9 @@ RUN set -eux; \
 		setpriv \
 	;
 
-ENV VALKEY_VERSION 8.0.0-rc2
-ENV VALKEY_DOWNLOAD_URL https://github.com/valkey-io/valkey/archive/refs/tags/8.0.0-rc2.tar.gz
-ENV VALKEY_DOWNLOAD_SHA 7592865c60578cc6d9f5cd5f0a6f77d946ac21a71bf9863bcf18b5e2835ae065
+ENV VALKEY_VERSION 8.0.0
+ENV VALKEY_DOWNLOAD_URL https://github.com/valkey-io/valkey/archive/refs/tags/8.0.0.tar.gz
+ENV VALKEY_DOWNLOAD_SHA f87fef2ba81ae4bce891b874fba58cfde2d19370a3bcac20f0e17498b33c33c0
 
 RUN set -eux; \
 	\
@@ -100,7 +100,7 @@ RUN set -eux; \
 	valkey-cli --version; \
 	valkey-server --version; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"8.0.0-rc2","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.0-rc2?os_name=alpine&os_version=3.20"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"8.0.0","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.0?os_name=alpine&os_version=3.20"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
 
 RUN mkdir /data && chown valkey:valkey /data
 VOLUME /data

--- a/8.0/debian/Dockerfile
+++ b/8.0/debian/Dockerfile
@@ -20,9 +20,9 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
-ENV VALKEY_VERSION 8.0.0-rc2
-ENV VALKEY_DOWNLOAD_URL https://github.com/valkey-io/valkey/archive/refs/tags/8.0.0-rc2.tar.gz
-ENV VALKEY_DOWNLOAD_SHA 7592865c60578cc6d9f5cd5f0a6f77d946ac21a71bf9863bcf18b5e2835ae065
+ENV VALKEY_VERSION 8.0.0
+ENV VALKEY_DOWNLOAD_URL https://github.com/valkey-io/valkey/archive/refs/tags/8.0.0.tar.gz
+ENV VALKEY_DOWNLOAD_SHA f87fef2ba81ae4bce891b874fba58cfde2d19370a3bcac20f0e17498b33c33c0
 
 RUN set -eux; \
 	\
@@ -101,7 +101,7 @@ RUN set -eux; \
 	valkey-cli --version; \
 	valkey-server --version; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"8.0.0-rc2","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.0-rc2?os_name=debian&os_version=bookworm"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"8.0.0","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.0?os_name=debian&os_version=bookworm"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
 
 RUN mkdir /data && chown valkey:valkey /data
 VOLUME /data

--- a/dockerhub-description.md
+++ b/dockerhub-description.md
@@ -9,10 +9,10 @@
 # Supported tags and respective `Dockerfile` links
 - [`unstable`, `unstable-bookworm`](https://github.com/valkey-io/valkey-container/blob/master/unstable/debian/Dockerfile)
 - [`unstable-alpine`, `unstable-alpine3.20`](https://github.com/valkey-io/valkey-container/blob/master/unstable/alpine/Dockerfile)
-- [`8.0`, `8.0-bookworm`, `8.0.0`, `8.0.0-bookworm`](https://github.com/valkey-io/valkey-container/blob/master/8.0/debian/Dockerfile)
-- [`8.0-alpine`, `8.0.0-alpine3.20`, `8.0.0-alpine`, `8.0-alpine3.20`](https://github.com/valkey-io/valkey-container/blob/master/8.0/alpine/Dockerfile)
-- [`7`, `7-bookworm`, `7.2`, `7.2-bookworm`, `7.2.6`, `7.2.6-bookworm`, `bookworm`, `latest`](https://github.com/valkey-io/valkey-container/blob/master/7.2/debian/Dockerfile)
-- [`7-alpine`, `7-alpine3.20`, `7.2-alpine`, `7.2-alpine3.20`, `7.2.6-alpine`, `7.2.6-alpine3.20`, `alpine`, `alpine3.20`](https://github.com/valkey-io/valkey-container/blob/master/7.2/alpine/Dockerfile)
+- [`8.0.0`, `8.0`, `8`, `latest`, `8.0.0-bookworm`, `8.0-bookworm`, `8-bookworm`, `bookworm`](https://github.com/valkey-io/valkey-container/blob/master/8.0/debian/Dockerfile)
+- [`8.0.0-alpine`, `8.0-alpine`, `8-alpine`, `alpine`, `8.0.0-alpine3.20`, `8.0-alpine3.20`, `8-alpine3.20`, `alpine3.20`](https://github.com/valkey-io/valkey-container/blob/master/8.0/alpine/Dockerfile)
+- [`7.2.6`, `7.2`, `7`, `7.2.6-bookworm`, `7.2-bookworm`, `7-bookworm`](https://github.com/valkey-io/valkey-container/blob/master/7.2/debian/Dockerfile)
+- [`7.2.6-alpine`, `7.2-alpine`, `7-alpine`, `7.2.6-alpine3.20`, `7.2-alpine3.20`, `7-alpine3.20`](https://github.com/valkey-io/valkey-container/blob/master/7.2/alpine/Dockerfile)
 
 What is [Valkey](https://github.com/valkey-io/valkey)?
 --------------

--- a/dockerhub-description.md
+++ b/dockerhub-description.md
@@ -9,8 +9,8 @@
 # Supported tags and respective `Dockerfile` links
 - [`unstable`, `unstable-bookworm`](https://github.com/valkey-io/valkey-container/blob/master/unstable/debian/Dockerfile)
 - [`unstable-alpine`, `unstable-alpine3.20`](https://github.com/valkey-io/valkey-container/blob/master/unstable/alpine/Dockerfile)
-- [`8.0`, `8.0-bookworm`, `8.0.0-rc2`, `8.0.0-rc2-bookworm`](https://github.com/valkey-io/valkey-container/blob/master/8.0/debian/Dockerfile)
-- [`8.0-alpine`, `8.0.0-rc2-alpine3.20`, `8.0.0-rc2-alpine`, `8.0-alpine3.20`](https://github.com/valkey-io/valkey-container/blob/master/8.0/alpine/Dockerfile)
+- [`8.0`, `8.0-bookworm`, `8.0.0`, `8.0.0-bookworm`](https://github.com/valkey-io/valkey-container/blob/master/8.0/debian/Dockerfile)
+- [`8.0-alpine`, `8.0.0-alpine3.20`, `8.0.0-alpine`, `8.0-alpine3.20`](https://github.com/valkey-io/valkey-container/blob/master/8.0/alpine/Dockerfile)
 - [`7`, `7-bookworm`, `7.2`, `7.2-bookworm`, `7.2.6`, `7.2.6-bookworm`, `bookworm`, `latest`](https://github.com/valkey-io/valkey-container/blob/master/7.2/debian/Dockerfile)
 - [`7-alpine`, `7-alpine3.20`, `7.2-alpine`, `7.2-alpine3.20`, `7.2.6-alpine`, `7.2.6-alpine3.20`, `alpine`, `alpine3.20`](https://github.com/valkey-io/valkey-container/blob/master/7.2/alpine/Dockerfile)
 

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -2,7 +2,8 @@
 set -Eeuo pipefail
 
 declare -A aliases=(
-	[7.2]='7 latest'
+	[7.2]='7'
+	[8.0]='8 latest'
 )
 
 self="$(basename "$BASH_SOURCE")"

--- a/versions.json
+++ b/versions.json
@@ -11,9 +11,9 @@
     }
   },
   "8.0": {
-    "version": "8.0.0-rc2",
-    "url": "https://github.com/valkey-io/valkey/archive/refs/tags/8.0.0-rc2.tar.gz",
-    "sha256": "7592865c60578cc6d9f5cd5f0a6f77d946ac21a71bf9863bcf18b5e2835ae065",
+    "version": "8.0.0",
+    "url": "https://github.com/valkey-io/valkey/archive/refs/tags/8.0.0.tar.gz",
+    "sha256": "f87fef2ba81ae4bce891b874fba58cfde2d19370a3bcac20f0e17498b33c33c0",
     "debian": {
       "version": "bookworm"
     },


### PR DESCRIPTION
Tested the workflow here on my personal repo: https://github.com/roshkhatri/valkey-container/actions/runs/10875308335/job/30174273701

Issue was that the secrets are not available to the workflow if triggered using `workflow_call` event type,
They need to be specified from the source.