### PR TITLE
Fix custom Dockerfile description on Docker Hub

### DIFF
--- a/dockerhub-description.md
+++ b/dockerhub-description.md
@@ -63,7 +63,7 @@ $ docker run --env VALKEY_EXTRA_FLAGS='--save 60 1 --loglevel warning' valkey/va
 You can create your own Dockerfile that adds a valkey.conf from the context into /data/, like so.
 
 ```dockerfile
-FROM valkey
+FROM valkey/valkey
 COPY valkey.conf /usr/local/etc/valkey/valkey.conf
 CMD [ "valkey-server", "/usr/local/etc/valkey/valkey.conf" ]
 ```


### PR DESCRIPTION
The code before the change causes the following error.

> failed to solve: valkey: failed to resolve source metadata for docker.io/library/valkey:latest: pull access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed 