### PR TITLE
Divide release tags according to release stage

### DIFF
--- a/dockerhub-description.md
+++ b/dockerhub-description.md
@@ -7,14 +7,22 @@
 	Please open an Issue stating your question on [the Valkey Community](https://github.com/valkey-io/valkey-container/issues).
 
 # Supported tags and respective `Dockerfile` links
+
+## Latest unstable
+
 - [`unstable`, `unstable-bookworm`](https://github.com/valkey-io/valkey-container/blob/master/unstable/debian/Dockerfile)
 - [`unstable-alpine`, `unstable-alpine3.21`](https://github.com/valkey-io/valkey-container/blob/master/unstable/alpine/Dockerfile)
+
+## Release candidates
+
+- [`8.1-alpine`, `8.1.0-rc1-alpine`, `8.1.0-rc1-alpine3.21`, `8.1-alpine3.21`](https://github.com/valkey-io/valkey-container/blob/master/8.1/alpine/Dockerfile)
+- [`8.1.0-rc1`, `8.1`, `8.1.0-rc1-bookworm`, `8.1-bookworm`](https://github.com/valkey-io/valkey-container/blob/master/8.1/debian/Dockerfile)
+
+## Official releases
 - [`8.0.2`, `8.0`, `8`, `latest`, `8.0.2-bookworm`, `8.0-bookworm`, `8-bookworm`, `bookworm`](https://github.com/valkey-io/valkey-container/blob/master/8.0/debian/Dockerfile)
 - [`8.0.2-alpine`, `8.0-alpine`, `8-alpine`, `alpine`, `8.0.2-alpine3.21`, `8.0-alpine3.21`, `8-alpine3.21`, `alpine3.21`](https://github.com/valkey-io/valkey-container/blob/master/8.0/alpine/Dockerfile)
 - [`7.2.8`, `7.2`, `7`, `7.2.8-bookworm`, `7.2-bookworm`, `7-bookworm`](https://github.com/valkey-io/valkey-container/blob/master/7.2/debian/Dockerfile)
 - [`7.2.8-alpine`, `7.2-alpine`, `7-alpine`, `7.2.8-alpine3.21`, `7.2-alpine3.21`, `7-alpine3.21`](https://github.com/valkey-io/valkey-container/blob/master/7.2/alpine/Dockerfile)
-- [`8.1-alpine`, `8.1.0-rc1-alpine`, `8.1.0-rc1-alpine3.21`, `8.1-alpine3.21`](https://github.com/valkey-io/valkey-container/blob/master/8.1/alpine/Dockerfile)
-- [`8.1.0-rc1`, `8.1`, `8.1.0-rc1-bookworm`, `8.1-bookworm`](https://github.com/valkey-io/valkey-container/blob/master/8.1/debian/Dockerfile)
 
 What is [Valkey](https://github.com/valkey-io/valkey)?
 --------------

--- a/dockerhub-description.md
+++ b/dockerhub-description.md
@@ -8,21 +8,23 @@
 
 # Supported tags and respective `Dockerfile` links
 
-## Latest unstable
+## Official releases
 
-- [`unstable`, `unstable-bookworm`](https://github.com/valkey-io/valkey-container/blob/master/unstable/debian/Dockerfile)
-- [`unstable-alpine`, `unstable-alpine3.21`](https://github.com/valkey-io/valkey-container/blob/master/unstable/alpine/Dockerfile)
+- [`8.0.2`, `8.0`, `8`, `latest`, `8.0.2-bookworm`, `8.0-bookworm`, `8-bookworm`, `bookworm`](https://github.com/valkey-io/valkey-container/blob/master/8.0/debian/Dockerfile)
+- [`8.0.2-alpine`, `8.0-alpine`, `8-alpine`, `alpine`, `8.0.2-alpine3.21`, `8.0-alpine3.21`, `8-alpine3.21`, `alpine3.21`](https://github.com/valkey-io/valkey-container/blob/master/8.0/alpine/Dockerfile)
+- [`7.2.8`, `7.2`, `7`, `7.2.8-bookworm`, `7.2-bookworm`, `7-bookworm`](https://github.com/valkey-io/valkey-container/blob/master/7.2/debian/Dockerfile)
+- [`7.2.8-alpine`, `7.2-alpine`, `7-alpine`, `7.2.8-alpine3.21`, `7.2-alpine3.21`, `7-alpine3.21`](https://github.com/valkey-io/valkey-container/blob/master/7.2/alpine/Dockerfile)
 
 ## Release candidates
 
 - [`8.1-alpine`, `8.1.0-rc1-alpine`, `8.1.0-rc1-alpine3.21`, `8.1-alpine3.21`](https://github.com/valkey-io/valkey-container/blob/master/8.1/alpine/Dockerfile)
 - [`8.1.0-rc1`, `8.1`, `8.1.0-rc1-bookworm`, `8.1-bookworm`](https://github.com/valkey-io/valkey-container/blob/master/8.1/debian/Dockerfile)
 
-## Official releases
-- [`8.0.2`, `8.0`, `8`, `latest`, `8.0.2-bookworm`, `8.0-bookworm`, `8-bookworm`, `bookworm`](https://github.com/valkey-io/valkey-container/blob/master/8.0/debian/Dockerfile)
-- [`8.0.2-alpine`, `8.0-alpine`, `8-alpine`, `alpine`, `8.0.2-alpine3.21`, `8.0-alpine3.21`, `8-alpine3.21`, `alpine3.21`](https://github.com/valkey-io/valkey-container/blob/master/8.0/alpine/Dockerfile)
-- [`7.2.8`, `7.2`, `7`, `7.2.8-bookworm`, `7.2-bookworm`, `7-bookworm`](https://github.com/valkey-io/valkey-container/blob/master/7.2/debian/Dockerfile)
-- [`7.2.8-alpine`, `7.2-alpine`, `7-alpine`, `7.2.8-alpine3.21`, `7.2-alpine3.21`, `7-alpine3.21`](https://github.com/valkey-io/valkey-container/blob/master/7.2/alpine/Dockerfile)
+## Latest unstable
+
+- [`unstable`, `unstable-bookworm`](https://github.com/valkey-io/valkey-container/blob/master/unstable/debian/Dockerfile)
+- [`unstable-alpine`, `unstable-alpine3.21`](https://github.com/valkey-io/valkey-container/blob/master/unstable/alpine/Dockerfile)
+
 
 What is [Valkey](https://github.com/valkey-io/valkey)?
 --------------


### PR DESCRIPTION
Currently our container release tags are not capturing the exact state of the release.
For the unstable it might be clearer to understand that this is an unstable branch based container, but for the release candidates it might mistakenly thought as an official release.