### PR TITLE
ci: Push images to GitHub Container Registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,9 +105,8 @@ jobs:
         with:
           file: ./${{ matrix.meta.entries[0].directory }}/Dockerfile
           push: true
-          tags: |-
-            ${{ steps.modify_tags.outputs.docker_hub_tags }}
-            ${{ steps.modify_tags.outputs.ghcr_tags }}
+          tags: >-
+            ${{ steps.modify_tags.outputs.docker_hub_tags }},${{ steps.modify_tags.outputs.ghcr_tags }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           provenance: false
           load: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,14 +56,17 @@ jobs:
 
   build_and_push:
     if: |
-      ((github.event_name == 'push' || github.event_name == 'schedule') && 
+      ((github.event_name == 'push' || github.event_name == 'schedule') &&
       github.ref == 'refs/heads/mainline')
-    needs: 
+    needs:
       - generate-jobs
       - test
     strategy: ${{ fromJson(needs.generate-jobs.outputs.strategy) }}
     name: ${{ matrix.name }} - Build and push
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      packages: write
     steps:
         # Tags are created by generate.sh in the format `valkey-container:<tag>`
         # This step modifies the tags to `account/valkey:<tag>` to be provided to build-push github action.
@@ -71,8 +74,10 @@ jobs:
         id: modify_tags
         run: |
           original_tags="${{ toJson(matrix.meta.entries[0].tags) }}"
-          tags=$(echo $original_tags | sed 's/valkey-container/${{ secrets.DOCKERHUB_ACCOUNT }}\/valkey/g'| sed 's/\[ *//; s/ *\]//; s/ //g')
-          echo "modified_tags=$tags" >> $GITHUB_OUTPUT
+          docker_hub_tags=$(echo $original_tags | sed 's/valkey-container/${{ secrets.DOCKERHUB_ACCOUNT }}\/valkey/g'| sed 's/\[ *//; s/ *\]//; s/ //g')
+          ghcr_tags=$(echo $original_tags | sed 's/valkey-container/ghcr.io\/${{ github.repository_owner }}\/valkey/g'| sed 's/\[ *//; s/ *\]//; s/ //g')
+          echo "docker_hub_tags=$docker_hub_tags" >> $GITHUB_OUTPUT
+          echo "ghcr_tags=$ghcr_tags" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -87,12 +92,21 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           file: ./${{ matrix.meta.entries[0].directory }}/Dockerfile
           push: true
-          tags: ${{ steps.modify_tags.outputs.modified_tags }}
+          tags: |-
+            ${{ steps.modify_tags.outputs.docker_hub_tags }}
+            ${{ steps.modify_tags.outputs.ghcr_tags }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           provenance: false
           load: false
@@ -100,7 +114,7 @@ jobs:
   update-dockerhub-description:
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/mainline')
-    needs: 
+    needs:
       - generate-jobs
       - test
       - build_and_push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,8 @@ jobs:
       packages: write
     steps:
         # Tags are created by generate.sh in the format `valkey-container:<tag>`
-        # This step modifies the tags to `account/valkey:<tag>` to be provided to build-push github action.
+        # For Docker Hub this step modifies the tags to `account/valkey:<tag>` to be provided to build-push github action.
+        # For GitHub Container Registry this step modifies the tags to `ghcr.io/<repo-owner>/valkey:<tag>` to be provided to build-push github action.
       - name: Modify Tags
         id: modify_tags
         run: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # valkey-container
 
-This Project is the Git repo of the [Valkey "Official Image"](https://hub.docker.com/r/valkey/valkey/)
+This Project is the Git repo of Valkey "Official Images" on [Dockerhub](https://hub.docker.com/r/valkey/valkey/) and [GitHub Container Registry](https://ghcr.io/valkey-io/valkey).
 
 The Project is now maintained by [the Valkey Community](https://github.com/valkey-io/valkey/)
 and it was forked from [docker-library/redis](https://github.com/docker-library/redis).

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ This Project is the Git repo of the [Valkey "Official Image"](https://hub.docker
 The Project is now maintained by [the Valkey Community](https://github.com/valkey-io/valkey/)
 and it was forked from [docker-library/redis](https://github.com/docker-library/redis).
 
-Alternatively the images can also be found on the [GitHub Container Registry](https://ghcr.io/valkey-io/valkey).
-
 ## When should you build and publish new Docker Image?
 
 You should build and publish a new Docker Image after a new major, minor or patch version of Valkey is released on the [main Valkey repository](https://github.com/valkey-io/valkey).

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This Project is the Git repo of the [Valkey "Official Image"](https://hub.docker
 The Project is now maintained by [the Valkey Community](https://github.com/valkey-io/valkey/)
 and it was forked from [docker-library/redis](https://github.com/docker-library/redis).
 
+Alternatively the images can also be found on the [GitHub Container Registry](https://ghcr.io/valkey-io/valkey).
+
 ## When should you build and publish new Docker Image?
 
 You should build and publish a new Docker Image after a new major, minor or patch version of Valkey is released on the [main Valkey repository](https://github.com/valkey-io/valkey).


### PR DESCRIPTION
This PR should add support for pushing container images to GitHub Container Registry under the `valkey-io` organization.

The resulting images will be tagged as `ghcr.io/valkey-io/valkey:<tag>`

<details>
<summary>List of tags that will be created</summary>

- ghcr.io/valkey-io/valkey:unstable
- ghcr.io/valkey-io/valkey:unstable-bookworm
- ghcr.io/valkey-io/valkey:unstable-alpine
- ghcr.io/valkey-io/valkey:unstable-alpine3.21
- ghcr.io/valkey-io/valkey:8.0.2
- ghcr.io/valkey-io/valkey:8.0
- ghcr.io/valkey-io/valkey:8
- ghcr.io/valkey-io/valkey:latest
- ghcr.io/valkey-io/valkey:8.0.2-bookworm
- ghcr.io/valkey-io/valkey:8.0-bookworm
- ghcr.io/valkey-io/valkey:8-bookworm
- ghcr.io/valkey-io/valkey:bookworm
- ghcr.io/valkey-io/valkey:8.0.2-alpine
- ghcr.io/valkey-io/valkey:8.0-alpine
- ghcr.io/valkey-io/valkey:8-alpine
- ghcr.io/valkey-io/valkey:alpine
- ghcr.io/valkey-io/valkey:8.0.2-alpine3.21
- ghcr.io/valkey-io/valkey:8.0-alpine3.21
- ghcr.io/valkey-io/valkey:8-alpine3.21
- ghcr.io/valkey-io/valkey:alpine3.21
- ghcr.io/valkey-io/valkey:8.1.0-rc1
- ghcr.io/valkey-io/valkey:8.1
- ghcr.io/valkey-io/valkey:8.1.0-rc1-bookworm
- ghcr.io/valkey-io/valkey:8.1-bookworm
- ghcr.io/valkey-io/valkey:8.1.0-rc1-alpine
- ghcr.io/valkey-io/valkey:8.1-alpine
- ghcr.io/valkey-io/valkey:8.1.0-rc1-alpine3.21
- ghcr.io/valkey-io/valkey:8.1-alpine3.21
- ghcr.io/valkey-io/valkey:7.2.8
- ghcr.io/valkey-io/valkey:7.2
- ghcr.io/valkey-io/valkey:7
- ghcr.io/valkey-io/valkey:7.2.8-bookworm
- ghcr.io/valkey-io/valkey:7.2-bookworm
- ghcr.io/valkey-io/valkey:7-bookworm
- ghcr.io/valkey-io/valkey:7.2.8-alpine
- ghcr.io/valkey-io/valkey:7.2-alpine
- ghcr.io/valkey-io/valkey:7-alpine
- ghcr.io/valkey-io/valkey:7.2.8-alpine3.21
- ghcr.io/valkey-io/valkey:7.2-alpine3.21
- ghcr.io/valkey-io/valkey:7-alpine3.21

</details>

Partly implements #17