### PR TITLE
g++ in Alpine .build-deps rather than leaving in final image

### DIFF
--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -31,6 +31,7 @@ RUN set -eux; \
 		coreutils \
 		dpkg-dev dpkg \
 		gcc \
+		g++ \
 		linux-headers \
 		make \
 		musl-dev \

--- a/8.0/alpine/Dockerfile
+++ b/8.0/alpine/Dockerfile
@@ -31,6 +31,7 @@ RUN set -eux; \
 		coreutils \
 		dpkg-dev dpkg \
 		gcc \
+		g++ \
 		linux-headers \
 		make \
 		musl-dev \

--- a/8.1/alpine/Dockerfile
+++ b/8.1/alpine/Dockerfile
@@ -31,6 +31,7 @@ RUN set -eux; \
 		coreutils \
 		dpkg-dev dpkg \
 		gcc \
+		g++ \
 		linux-headers \
 		make \
 		musl-dev \
@@ -73,8 +74,7 @@ RUN set -eux; \
 	grep -F "cd jemalloc && ./configure $extraJemallocConfigureFlags " /usr/src/valkey/deps/Makefile; \
 	\
 	echo "Version 8.1.1 is 8.1 or higher - enabling USE_FAST_FLOAT"; \
-			apk add --no-cache g++; \
-		export BUILD_TLS=yes USE_FAST_FLOAT=yes; \
+			export BUILD_TLS=yes USE_FAST_FLOAT=yes; \
 	make -C /usr/src/valkey -j "$(nproc)" all; \
 	make -C /usr/src/valkey install; \
 	\

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -47,6 +47,7 @@ RUN set -eux; \
 		coreutils \
 		dpkg-dev dpkg \
 		gcc \
+		g++ \
 		linux-headers \
 		make \
 		musl-dev \
@@ -110,7 +111,6 @@ RUN set -eux; \
 {{ if .version == "unstable" then ( -}}
 	echo "Unstable version detected — enabling USE_FAST_FLOAT"; \
 	{{ if env.variant == "alpine" then ( -}}
-		apk add --no-cache g++; \
 	{{ ) else ( -}}
 		apt-get update; \
 		apt-get install -y --no-install-recommends g++; \
@@ -120,7 +120,6 @@ RUN set -eux; \
 {{ ) elif ( (.version | split(".") | .[0] | tonumber) * 100 + (.version | split(".") | .[1] | tonumber) ) >= 801 then ( -}}
 	echo "Version {{ .version }} is 8.1 or higher - enabling USE_FAST_FLOAT"; \
 	{{ if env.variant == "alpine" then ( -}}
-		apk add --no-cache g++; \
 	{{ ) else ( -}}
 		apt-get update; \
 		apt-get install -y --no-install-recommends g++; \

--- a/unstable/alpine/Dockerfile
+++ b/unstable/alpine/Dockerfile
@@ -31,6 +31,7 @@ RUN set -eux; \
 		coreutils \
 		dpkg-dev dpkg \
 		gcc \
+		g++ \
 		linux-headers \
 		make \
 		musl-dev \
@@ -73,8 +74,7 @@ RUN set -eux; \
 	grep -F "cd jemalloc && ./configure $extraJemallocConfigureFlags " /usr/src/valkey/deps/Makefile; \
 	\
 	echo "Unstable version detected — enabling USE_FAST_FLOAT"; \
-			apk add --no-cache g++; \
-		export BUILD_TLS=yes USE_FAST_FLOAT=yes; \
+			export BUILD_TLS=yes USE_FAST_FLOAT=yes; \
 	make -C /usr/src/valkey -j "$(nproc)" all; \
 	make -C /usr/src/valkey install; \
 	\


### PR DESCRIPTION
Fixes https://github.com/valkey-io/valkey/issues/2040 #68 

add g++ in the `apk add --no-cache --virtual .build-deps ` line of alpine images rather than installing in its own step so that it can get cleaned up and not be left in the final image 