### PR TITLE
Switch to multi-stage build

### DIFF
--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -4,30 +4,18 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.21
+FROM alpine:3.21 AS base
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN set -eux; \
-# alpine already has a gid 999, so we'll use the next id
-	addgroup -S -g 1000 valkey; \
-	adduser -S -G valkey -u 999 valkey
-
-# runtime dependencies
-RUN set -eux; \
-	apk add --no-cache \
-# add tzdata for https://github.com/docker-library/valkey/issues/138
-		tzdata \
-		# add setpriv for step down from root.
-		setpriv \
-	;
+FROM base AS build
 
 ENV VALKEY_VERSION 7.2.9
-ENV VALKEY_DOWNLOAD_URL https://github.com/valkey-io/valkey/archive/refs/tags/7.2.9.tar.gz
 ENV VALKEY_DOWNLOAD_SHA d05cb3307752314083cf73628f2b8413a4445b8afb7ac27d77a29c663026e327
+
+ADD "https://github.com/valkey-io/valkey/archive/refs/tags/7.2.9.tar.gz" /valkey.tar.gz
 
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache \
 		coreutils \
 		dpkg-dev dpkg \
 		gcc \
@@ -36,14 +24,8 @@ RUN set -eux; \
 		make \
 		musl-dev \
 		openssl-dev \
-# install real "wget" to avoid:
-#   + wget -O valkey.tar.gz https://download.valkey.io/releases/valkey-6.0.6.tar.gz
-#   Connecting to download.valkey.io (45.60.121.1:80)
-#   wget: bad header line:     XxhODalH: btu; path=/; Max-Age=900
-		wget \
 	; \
 	\
-	wget -O valkey.tar.gz "$VALKEY_DOWNLOAD_URL"; \
 			echo "$VALKEY_DOWNLOAD_SHA *valkey.tar.gz" | sha256sum -c -; \
 		\
 	mkdir -p /usr/src/valkey; \
@@ -87,23 +69,32 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	rm -r /usr/src/valkey; \
-	\
-	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
-			| tr ',' '\n' \
-			| sort -u \
-			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-	)"; \
-	apk add --no-network --virtual .valkey-rundeps $runDeps; \
-	apk del --no-network .build-deps; \
-	\
-	valkey-cli --version; \
-	valkey-server --version; \
-	\
 	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"7.2.9","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@7.2.9?os_name=alpine&os_version=3.21"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
 
-RUN mkdir /data && chown valkey:valkey /data
+FROM base
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN set -eux; \
+# alpine already has a gid 999, so we'll use the next id
+	addgroup -S -g 1000 valkey; \
+	adduser -S -G valkey -u 999 valkey
+
+# runtime dependencies
+RUN set -eux; \
+	apk add --no-cache \
+# add tzdata for https://github.com/docker-library/valkey/issues/138
+		tzdata \
+		# add setpriv for step down from root.
+		setpriv \
+		openssl \
+	;
+
+# Install valkey built earlier
+COPY --from=build /usr/local /usr/local
+RUN mkdir /data && \
+	chown valkey:valkey /data && \
+	valkey-cli --version && \
+	valkey-server --version
 VOLUME /data
 WORKDIR /data
 

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -4,34 +4,19 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim AS base
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN set -eux; \
-	groupadd -r -g 999 valkey; \
-	useradd -r -g valkey -u 999 valkey
-
-# runtime dependencies
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-# add tzdata explicitly for https://github.com/docker-library/valkey/issues/138 (see also https://bugs.debian.org/837060 and related)
-		tzdata \
-	; \
-	rm -rf /var/lib/apt/lists/*
+FROM base AS build
 
 ENV VALKEY_VERSION 7.2.9
-ENV VALKEY_DOWNLOAD_URL https://github.com/valkey-io/valkey/archive/refs/tags/7.2.9.tar.gz
 ENV VALKEY_DOWNLOAD_SHA d05cb3307752314083cf73628f2b8413a4445b8afb7ac27d77a29c663026e327
+
+ADD "https://github.com/valkey-io/valkey/archive/refs/tags/7.2.9.tar.gz" /valkey.tar.gz
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		wget \
-		\
 		dpkg-dev \
 		gcc \
 		libc6-dev \
@@ -40,7 +25,6 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
-	wget -O valkey.tar.gz "$VALKEY_DOWNLOAD_URL"; \
 			echo "$VALKEY_DOWNLOAD_SHA *valkey.tar.gz" | sha256sum -c -; \
 		\
 	mkdir -p /usr/src/valkey; \
@@ -84,26 +68,31 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	rm -r /usr/src/valkey; \
-	\
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	find /usr/local -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
-		| sort -u \
-		| xargs -r dpkg-query --search \
-		| cut -d: -f1 \
-		| sort -u \
-		| xargs -r apt-mark manual \
-	; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	\
-	valkey-cli --version; \
-	valkey-server --version; \
-	\
 	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"7.2.9","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@7.2.9?os_name=debian&os_version=bookworm"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
 
-RUN mkdir /data && chown valkey:valkey /data
+FROM base
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN set -eux; \
+	groupadd -r -g 999 valkey; \
+	useradd -r -g valkey -u 999 valkey
+
+# runtime dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# add tzdata explicitly for https://github.com/docker-library/valkey/issues/138 (see also https://bugs.debian.org/837060 and related)
+		tzdata \
+		libssl3 \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+# Install valkey built earlier
+COPY --from=build /usr/local /usr/local
+RUN mkdir /data && \
+	chown valkey:valkey /data && \
+	valkey-cli --version && \
+	valkey-server --version
 VOLUME /data
 WORKDIR /data
 

--- a/8.0/alpine/Dockerfile
+++ b/8.0/alpine/Dockerfile
@@ -4,30 +4,18 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.21
+FROM alpine:3.21 AS base
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN set -eux; \
-# alpine already has a gid 999, so we'll use the next id
-	addgroup -S -g 1000 valkey; \
-	adduser -S -G valkey -u 999 valkey
-
-# runtime dependencies
-RUN set -eux; \
-	apk add --no-cache \
-# add tzdata for https://github.com/docker-library/valkey/issues/138
-		tzdata \
-		# add setpriv for step down from root.
-		setpriv \
-	;
+FROM base AS build
 
 ENV VALKEY_VERSION 8.0.3
-ENV VALKEY_DOWNLOAD_URL https://github.com/valkey-io/valkey/archive/refs/tags/8.0.3.tar.gz
 ENV VALKEY_DOWNLOAD_SHA 9141b6a91572e714fae8bc01e5031828ac6a8eb8e012e6836673d18dbfe4a47b
+
+ADD "https://github.com/valkey-io/valkey/archive/refs/tags/8.0.3.tar.gz" /valkey.tar.gz
 
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache \
 		coreutils \
 		dpkg-dev dpkg \
 		gcc \
@@ -36,14 +24,8 @@ RUN set -eux; \
 		make \
 		musl-dev \
 		openssl-dev \
-# install real "wget" to avoid:
-#   + wget -O valkey.tar.gz https://download.valkey.io/releases/valkey-6.0.6.tar.gz
-#   Connecting to download.valkey.io (45.60.121.1:80)
-#   wget: bad header line:     XxhODalH: btu; path=/; Max-Age=900
-		wget \
 	; \
 	\
-	wget -O valkey.tar.gz "$VALKEY_DOWNLOAD_URL"; \
 			echo "$VALKEY_DOWNLOAD_SHA *valkey.tar.gz" | sha256sum -c -; \
 		\
 	mkdir -p /usr/src/valkey; \
@@ -87,23 +69,32 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	rm -r /usr/src/valkey; \
-	\
-	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
-			| tr ',' '\n' \
-			| sort -u \
-			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-	)"; \
-	apk add --no-network --virtual .valkey-rundeps $runDeps; \
-	apk del --no-network .build-deps; \
-	\
-	valkey-cli --version; \
-	valkey-server --version; \
-	\
 	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"8.0.3","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.3?os_name=alpine&os_version=3.21"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
 
-RUN mkdir /data && chown valkey:valkey /data
+FROM base
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN set -eux; \
+# alpine already has a gid 999, so we'll use the next id
+	addgroup -S -g 1000 valkey; \
+	adduser -S -G valkey -u 999 valkey
+
+# runtime dependencies
+RUN set -eux; \
+	apk add --no-cache \
+# add tzdata for https://github.com/docker-library/valkey/issues/138
+		tzdata \
+		# add setpriv for step down from root.
+		setpriv \
+		openssl \
+	;
+
+# Install valkey built earlier
+COPY --from=build /usr/local /usr/local
+RUN mkdir /data && \
+	chown valkey:valkey /data && \
+	valkey-cli --version && \
+	valkey-server --version
 VOLUME /data
 WORKDIR /data
 

--- a/8.0/debian/Dockerfile
+++ b/8.0/debian/Dockerfile
@@ -4,34 +4,19 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim AS base
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN set -eux; \
-	groupadd -r -g 999 valkey; \
-	useradd -r -g valkey -u 999 valkey
-
-# runtime dependencies
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-# add tzdata explicitly for https://github.com/docker-library/valkey/issues/138 (see also https://bugs.debian.org/837060 and related)
-		tzdata \
-	; \
-	rm -rf /var/lib/apt/lists/*
+FROM base AS build
 
 ENV VALKEY_VERSION 8.0.3
-ENV VALKEY_DOWNLOAD_URL https://github.com/valkey-io/valkey/archive/refs/tags/8.0.3.tar.gz
 ENV VALKEY_DOWNLOAD_SHA 9141b6a91572e714fae8bc01e5031828ac6a8eb8e012e6836673d18dbfe4a47b
+
+ADD "https://github.com/valkey-io/valkey/archive/refs/tags/8.0.3.tar.gz" /valkey.tar.gz
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		wget \
-		\
 		dpkg-dev \
 		gcc \
 		libc6-dev \
@@ -40,7 +25,6 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
-	wget -O valkey.tar.gz "$VALKEY_DOWNLOAD_URL"; \
 			echo "$VALKEY_DOWNLOAD_SHA *valkey.tar.gz" | sha256sum -c -; \
 		\
 	mkdir -p /usr/src/valkey; \
@@ -84,26 +68,31 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	rm -r /usr/src/valkey; \
-	\
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	find /usr/local -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
-		| sort -u \
-		| xargs -r dpkg-query --search \
-		| cut -d: -f1 \
-		| sort -u \
-		| xargs -r apt-mark manual \
-	; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	\
-	valkey-cli --version; \
-	valkey-server --version; \
-	\
 	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"8.0.3","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.3?os_name=debian&os_version=bookworm"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
 
-RUN mkdir /data && chown valkey:valkey /data
+FROM base
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN set -eux; \
+	groupadd -r -g 999 valkey; \
+	useradd -r -g valkey -u 999 valkey
+
+# runtime dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# add tzdata explicitly for https://github.com/docker-library/valkey/issues/138 (see also https://bugs.debian.org/837060 and related)
+		tzdata \
+		libssl3 \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+# Install valkey built earlier
+COPY --from=build /usr/local /usr/local
+RUN mkdir /data && \
+	chown valkey:valkey /data && \
+	valkey-cli --version && \
+	valkey-server --version
 VOLUME /data
 WORKDIR /data
 

--- a/8.1/alpine/Dockerfile
+++ b/8.1/alpine/Dockerfile
@@ -4,30 +4,18 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.21
+FROM alpine:3.21 AS base
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN set -eux; \
-# alpine already has a gid 999, so we'll use the next id
-	addgroup -S -g 1000 valkey; \
-	adduser -S -G valkey -u 999 valkey
-
-# runtime dependencies
-RUN set -eux; \
-	apk add --no-cache \
-# add tzdata for https://github.com/docker-library/valkey/issues/138
-		tzdata \
-		# add setpriv for step down from root.
-		setpriv \
-	;
+FROM base AS build
 
 ENV VALKEY_VERSION 8.1.1
-ENV VALKEY_DOWNLOAD_URL https://github.com/valkey-io/valkey/archive/refs/tags/8.1.1.tar.gz
 ENV VALKEY_DOWNLOAD_SHA 3355fbd5458d853ab201d2c046ffca9f078000587ccbe9a6c585110f146ad2c5
+
+ADD "https://github.com/valkey-io/valkey/archive/refs/tags/8.1.1.tar.gz" /valkey.tar.gz
 
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache \
 		coreutils \
 		dpkg-dev dpkg \
 		gcc \
@@ -36,14 +24,8 @@ RUN set -eux; \
 		make \
 		musl-dev \
 		openssl-dev \
-# install real "wget" to avoid:
-#   + wget -O valkey.tar.gz https://download.valkey.io/releases/valkey-6.0.6.tar.gz
-#   Connecting to download.valkey.io (45.60.121.1:80)
-#   wget: bad header line:     XxhODalH: btu; path=/; Max-Age=900
-		wget \
 	; \
 	\
-	wget -O valkey.tar.gz "$VALKEY_DOWNLOAD_URL"; \
 			echo "$VALKEY_DOWNLOAD_SHA *valkey.tar.gz" | sha256sum -c -; \
 		\
 	mkdir -p /usr/src/valkey; \
@@ -88,23 +70,32 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	rm -r /usr/src/valkey; \
-	\
-	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
-			| tr ',' '\n' \
-			| sort -u \
-			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-	)"; \
-	apk add --no-network --virtual .valkey-rundeps $runDeps; \
-	apk del --no-network .build-deps; \
-	\
-	valkey-cli --version; \
-	valkey-server --version; \
-	\
 	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"8.1.1","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.1.1?os_name=alpine&os_version=3.21"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
 
-RUN mkdir /data && chown valkey:valkey /data
+FROM base
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN set -eux; \
+# alpine already has a gid 999, so we'll use the next id
+	addgroup -S -g 1000 valkey; \
+	adduser -S -G valkey -u 999 valkey
+
+# runtime dependencies
+RUN set -eux; \
+	apk add --no-cache \
+# add tzdata for https://github.com/docker-library/valkey/issues/138
+		tzdata \
+		# add setpriv for step down from root.
+		setpriv \
+		openssl \
+	;
+
+# Install valkey built earlier
+COPY --from=build /usr/local /usr/local
+RUN mkdir /data && \
+	chown valkey:valkey /data && \
+	valkey-cli --version && \
+	valkey-server --version
 VOLUME /data
 WORKDIR /data
 

--- a/8.1/debian/Dockerfile
+++ b/8.1/debian/Dockerfile
@@ -4,34 +4,19 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim AS base
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN set -eux; \
-	groupadd -r -g 999 valkey; \
-	useradd -r -g valkey -u 999 valkey
-
-# runtime dependencies
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-# add tzdata explicitly for https://github.com/docker-library/valkey/issues/138 (see also https://bugs.debian.org/837060 and related)
-		tzdata \
-	; \
-	rm -rf /var/lib/apt/lists/*
+FROM base AS build
 
 ENV VALKEY_VERSION 8.1.1
-ENV VALKEY_DOWNLOAD_URL https://github.com/valkey-io/valkey/archive/refs/tags/8.1.1.tar.gz
 ENV VALKEY_DOWNLOAD_SHA 3355fbd5458d853ab201d2c046ffca9f078000587ccbe9a6c585110f146ad2c5
+
+ADD "https://github.com/valkey-io/valkey/archive/refs/tags/8.1.1.tar.gz" /valkey.tar.gz
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		wget \
-		\
 		dpkg-dev \
 		gcc \
 		libc6-dev \
@@ -40,7 +25,6 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
-	wget -O valkey.tar.gz "$VALKEY_DOWNLOAD_URL"; \
 			echo "$VALKEY_DOWNLOAD_SHA *valkey.tar.gz" | sha256sum -c -; \
 		\
 	mkdir -p /usr/src/valkey; \
@@ -88,26 +72,31 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	rm -r /usr/src/valkey; \
-	\
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	find /usr/local -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
-		| sort -u \
-		| xargs -r dpkg-query --search \
-		| cut -d: -f1 \
-		| sort -u \
-		| xargs -r apt-mark manual \
-	; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	\
-	valkey-cli --version; \
-	valkey-server --version; \
-	\
 	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"8.1.1","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.1.1?os_name=debian&os_version=bookworm"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
 
-RUN mkdir /data && chown valkey:valkey /data
+FROM base
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN set -eux; \
+	groupadd -r -g 999 valkey; \
+	useradd -r -g valkey -u 999 valkey
+
+# runtime dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# add tzdata explicitly for https://github.com/docker-library/valkey/issues/138 (see also https://bugs.debian.org/837060 and related)
+		tzdata \
+		libssl3 \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+# Install valkey built earlier
+COPY --from=build /usr/local /usr/local
+RUN mkdir /data && \
+	chown valkey:valkey /data && \
+	valkey-cli --version && \
+	valkey-server --version
 VOLUME /data
 WORKDIR /data
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,49 +1,21 @@
 {{ include ".template-helper-functions" -}}
 {{ if env.variant == "alpine" then ( -}}
-FROM alpine:{{ .alpine.version }}
+FROM alpine:{{ .alpine.version }} AS base
 {{ ) else ( -}}
-FROM debian:{{ .debian.version }}-slim
+FROM debian:{{ .debian.version }}-slim AS base
 {{ ) end -}}
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-{{ if env.variant == "alpine" then ( -}}
-RUN set -eux; \
-# alpine already has a gid 999, so we'll use the next id
-	addgroup -S -g 1000 valkey; \
-	adduser -S -G valkey -u 999 valkey
-{{ ) else ( -}}
-RUN set -eux; \
-	groupadd -r -g 999 valkey; \
-	useradd -r -g valkey -u 999 valkey
-{{ ) end -}}
-
-# runtime dependencies
-{{ if env.variant == "alpine" then ( -}}
-RUN set -eux; \
-	apk add --no-cache \
-# add tzdata for https://github.com/docker-library/valkey/issues/138
-		tzdata \
-		# add setpriv for step down from root.
-		setpriv \
-	;
-{{ ) else ( -}}
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-# add tzdata explicitly for https://github.com/docker-library/valkey/issues/138 (see also https://bugs.debian.org/837060 and related)
-		tzdata \
-	; \
-	rm -rf /var/lib/apt/lists/*
-{{ ) end -}}
+FROM base AS build
 
 ENV VALKEY_VERSION {{ .version }}
-ENV VALKEY_DOWNLOAD_URL {{ .url }}
 ENV VALKEY_DOWNLOAD_SHA {{ .sha256 // error("no sha256 for \(.version) (\(env.version))") }}
+
+ADD "{{ .url }}" /valkey.tar.gz
 
 RUN set -eux; \
 	\
 {{ if env.variant == "alpine" then ( -}}
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache \
 		coreutils \
 		dpkg-dev dpkg \
 		gcc \
@@ -52,19 +24,10 @@ RUN set -eux; \
 		make \
 		musl-dev \
 		openssl-dev \
-# install real "wget" to avoid:
-#   + wget -O valkey.tar.gz https://download.valkey.io/releases/valkey-6.0.6.tar.gz
-#   Connecting to download.valkey.io (45.60.121.1:80)
-#   wget: bad header line:     XxhODalH: btu; path=/; Max-Age=900
-		wget \
 	; \
 {{ ) else ( -}}
-	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		wget \
-		\
 		dpkg-dev \
 		gcc \
 		libc6-dev \
@@ -74,7 +37,6 @@ RUN set -eux; \
 	rm -rf /var/lib/apt/lists/*; \
 {{ ) end -}}
 	\
-	wget -O valkey.tar.gz "$VALKEY_DOWNLOAD_URL"; \
 	{{ if .version == "unstable" then ( -}}
 		echo "Unstable Valkey version, do not compare SHA256SUM" ;\
 	{{ ) else ( -}}
@@ -142,34 +104,6 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	rm -r /usr/src/valkey; \
-	\
-{{ if env.variant == "alpine" then ( -}}
-	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
-			| tr ',' '\n' \
-			| sort -u \
-			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-	)"; \
-	apk add --no-network --virtual .valkey-rundeps $runDeps; \
-	apk del --no-network .build-deps; \
-{{ ) else ( -}}
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	find /usr/local -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
-		| sort -u \
-		| xargs -r dpkg-query --search \
-		| cut -d: -f1 \
-		| sort -u \
-		| xargs -r apt-mark manual \
-	; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-{{ ) end -}}
-	\
-	valkey-cli --version; \
-	valkey-server --version; \
-	\
 	echo {{
 		{
 			name: "valkey-server",
@@ -193,7 +127,47 @@ RUN set -eux; \
 		} | sbom | tostring | @sh
 	}} > /usr/local/valkey.spdx.json
 
-RUN mkdir /data && chown valkey:valkey /data
+FROM base
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+{{ if env.variant == "alpine" then ( -}}
+RUN set -eux; \
+# alpine already has a gid 999, so we'll use the next id
+	addgroup -S -g 1000 valkey; \
+	adduser -S -G valkey -u 999 valkey
+{{ ) else ( -}}
+RUN set -eux; \
+	groupadd -r -g 999 valkey; \
+	useradd -r -g valkey -u 999 valkey
+{{ ) end -}}
+
+# runtime dependencies
+{{ if env.variant == "alpine" then ( -}}
+RUN set -eux; \
+	apk add --no-cache \
+# add tzdata for https://github.com/docker-library/valkey/issues/138
+		tzdata \
+		# add setpriv for step down from root.
+		setpriv \
+		openssl \
+	;
+{{ ) else ( -}}
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# add tzdata explicitly for https://github.com/docker-library/valkey/issues/138 (see also https://bugs.debian.org/837060 and related)
+		tzdata \
+		libssl3 \
+	; \
+	rm -rf /var/lib/apt/lists/*
+{{ ) end -}}
+
+# Install valkey built earlier
+COPY --from=build /usr/local /usr/local
+RUN mkdir /data && \
+	chown valkey:valkey /data && \
+	valkey-cli --version && \
+	valkey-server --version
 VOLUME /data
 WORKDIR /data
 

--- a/unstable/alpine/Dockerfile
+++ b/unstable/alpine/Dockerfile
@@ -4,30 +4,18 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.21
+FROM alpine:3.21 AS base
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN set -eux; \
-# alpine already has a gid 999, so we'll use the next id
-	addgroup -S -g 1000 valkey; \
-	adduser -S -G valkey -u 999 valkey
-
-# runtime dependencies
-RUN set -eux; \
-	apk add --no-cache \
-# add tzdata for https://github.com/docker-library/valkey/issues/138
-		tzdata \
-		# add setpriv for step down from root.
-		setpriv \
-	;
+FROM base AS build
 
 ENV VALKEY_VERSION unstable
-ENV VALKEY_DOWNLOAD_URL https://github.com/valkey-io/valkey/archive/unstable.tar.gz
 ENV VALKEY_DOWNLOAD_SHA 0000000000000000000000000000000000000000000000000000000000000000
+
+ADD "https://github.com/valkey-io/valkey/archive/unstable.tar.gz" /valkey.tar.gz
 
 RUN set -eux; \
 	\
-	apk add --no-cache --virtual .build-deps \
+	apk add --no-cache \
 		coreutils \
 		dpkg-dev dpkg \
 		gcc \
@@ -36,14 +24,8 @@ RUN set -eux; \
 		make \
 		musl-dev \
 		openssl-dev \
-# install real "wget" to avoid:
-#   + wget -O valkey.tar.gz https://download.valkey.io/releases/valkey-6.0.6.tar.gz
-#   Connecting to download.valkey.io (45.60.121.1:80)
-#   wget: bad header line:     XxhODalH: btu; path=/; Max-Age=900
-		wget \
 	; \
 	\
-	wget -O valkey.tar.gz "$VALKEY_DOWNLOAD_URL"; \
 			echo "Unstable Valkey version, do not compare SHA256SUM" ;\
 		\
 	mkdir -p /usr/src/valkey; \
@@ -88,23 +70,32 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	rm -r /usr/src/valkey; \
-	\
-	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \
-			| tr ',' '\n' \
-			| sort -u \
-			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-	)"; \
-	apk add --no-network --virtual .valkey-rundeps $runDeps; \
-	apk del --no-network .build-deps; \
-	\
-	valkey-cli --version; \
-	valkey-server --version; \
-	\
 	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"unstable","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@unstable?os_name=alpine&os_version=3.21"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
 
-RUN mkdir /data && chown valkey:valkey /data
+FROM base
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN set -eux; \
+# alpine already has a gid 999, so we'll use the next id
+	addgroup -S -g 1000 valkey; \
+	adduser -S -G valkey -u 999 valkey
+
+# runtime dependencies
+RUN set -eux; \
+	apk add --no-cache \
+# add tzdata for https://github.com/docker-library/valkey/issues/138
+		tzdata \
+		# add setpriv for step down from root.
+		setpriv \
+		openssl \
+	;
+
+# Install valkey built earlier
+COPY --from=build /usr/local /usr/local
+RUN mkdir /data && \
+	chown valkey:valkey /data && \
+	valkey-cli --version && \
+	valkey-server --version
 VOLUME /data
 WORKDIR /data
 

--- a/unstable/debian/Dockerfile
+++ b/unstable/debian/Dockerfile
@@ -4,34 +4,19 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim AS base
 
-# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
-RUN set -eux; \
-	groupadd -r -g 999 valkey; \
-	useradd -r -g valkey -u 999 valkey
-
-# runtime dependencies
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-# add tzdata explicitly for https://github.com/docker-library/valkey/issues/138 (see also https://bugs.debian.org/837060 and related)
-		tzdata \
-	; \
-	rm -rf /var/lib/apt/lists/*
+FROM base AS build
 
 ENV VALKEY_VERSION unstable
-ENV VALKEY_DOWNLOAD_URL https://github.com/valkey-io/valkey/archive/unstable.tar.gz
 ENV VALKEY_DOWNLOAD_SHA 0000000000000000000000000000000000000000000000000000000000000000
+
+ADD "https://github.com/valkey-io/valkey/archive/unstable.tar.gz" /valkey.tar.gz
 
 RUN set -eux; \
 	\
-	savedAptMark="$(apt-mark showmanual)"; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		wget \
-		\
 		dpkg-dev \
 		gcc \
 		libc6-dev \
@@ -40,7 +25,6 @@ RUN set -eux; \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
 	\
-	wget -O valkey.tar.gz "$VALKEY_DOWNLOAD_URL"; \
 			echo "Unstable Valkey version, do not compare SHA256SUM" ;\
 		\
 	mkdir -p /usr/src/valkey; \
@@ -88,26 +72,31 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	rm -r /usr/src/valkey; \
-	\
-	apt-mark auto '.*' > /dev/null; \
-	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
-	find /usr/local -type f -executable -exec ldd '{}' ';' \
-		| awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
-		| sort -u \
-		| xargs -r dpkg-query --search \
-		| cut -d: -f1 \
-		| sort -u \
-		| xargs -r apt-mark manual \
-	; \
-	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
-	\
-	valkey-cli --version; \
-	valkey-server --version; \
-	\
 	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"unstable","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@unstable?os_name=debian&os_version=bookworm"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
 
-RUN mkdir /data && chown valkey:valkey /data
+FROM base
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN set -eux; \
+	groupadd -r -g 999 valkey; \
+	useradd -r -g valkey -u 999 valkey
+
+# runtime dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# add tzdata explicitly for https://github.com/docker-library/valkey/issues/138 (see also https://bugs.debian.org/837060 and related)
+		tzdata \
+		libssl3 \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+# Install valkey built earlier
+COPY --from=build /usr/local /usr/local
+RUN mkdir /data && \
+	chown valkey:valkey /data && \
+	valkey-cli --version && \
+	valkey-server --version
 VOLUME /data
 WORKDIR /data
 


### PR DESCRIPTION
This simplifies the build pipeline, as no "cleanup" stage has to be done, and allow precise description of the runtime libraries required to use Valkey.

The result reduces Debian (uncompressed) image size from 140MB to 116MB (a 17% improvement), and allow certain tools like wget to be removed from the build by using native `ADD` instructions. The number of vulnerabilities (as reported by trivy) in the Debian image also drops from 693 to 77, where the main contributors are left-over build dependencies.

The Alpine image did not see any noticeable improvement, however

Closes #57.

