### PR TITLE
Add libgcc to Alpine image

### DIFF
--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -87,6 +87,7 @@ RUN set -eux; \
 		# add setpriv for step down from root.
 		setpriv \
 		openssl \
+		libgcc \
 	;
 
 # Install valkey built earlier

--- a/8.0/alpine/Dockerfile
+++ b/8.0/alpine/Dockerfile
@@ -87,6 +87,7 @@ RUN set -eux; \
 		# add setpriv for step down from root.
 		setpriv \
 		openssl \
+		libgcc \
 	;
 
 # Install valkey built earlier

--- a/8.1/alpine/Dockerfile
+++ b/8.1/alpine/Dockerfile
@@ -88,6 +88,7 @@ RUN set -eux; \
 		# add setpriv for step down from root.
 		setpriv \
 		openssl \
+		libgcc \
 	;
 
 # Install valkey built earlier

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -150,6 +150,7 @@ RUN set -eux; \
 		# add setpriv for step down from root.
 		setpriv \
 		openssl \
+		libgcc \
 	;
 {{ ) else ( -}}
 RUN set -eux; \

--- a/unstable/alpine/Dockerfile
+++ b/unstable/alpine/Dockerfile
@@ -88,6 +88,7 @@ RUN set -eux; \
 		# add setpriv for step down from root.
 		setpriv \
 		openssl \
+		libgcc \
 	;
 
 # Install valkey built earlier


### PR DESCRIPTION
On some architectures (i.e. armv7), valkey is linked to libgcc_s and as such requires this package to be installed.

Given that the package is 169.8KiB installed (<1% final image size), it's cheap enough to be added unconditionally to the image.