### PR TITLE
Enable systemd integration for Debian images

### DIFF
--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -56,6 +56,7 @@ RUN set -eux; \
 	grep -F "cd jemalloc && ./configure $extraJemallocConfigureFlags " /usr/src/valkey/deps/Makefile; \
 	\
 	export BUILD_TLS=yes; \
+	\
 	make -C /usr/src/valkey -j "$(nproc)" all; \
 	make -C /usr/src/valkey install; \
 	\

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -21,6 +21,7 @@ RUN set -eux; \
 		gcc \
 		libc6-dev \
 		libssl-dev \
+		libsystemd-dev \
 		make \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
@@ -55,6 +56,7 @@ RUN set -eux; \
 	grep -F "cd jemalloc && ./configure $extraJemallocConfigureFlags " /usr/src/valkey/deps/Makefile; \
 	\
 	export BUILD_TLS=yes; \
+	export USE_SYSTEMD=yes; \
 	make -C /usr/src/valkey -j "$(nproc)" all; \
 	make -C /usr/src/valkey install; \
 	\

--- a/8.0/alpine/Dockerfile
+++ b/8.0/alpine/Dockerfile
@@ -56,6 +56,7 @@ RUN set -eux; \
 	grep -F "cd jemalloc && ./configure $extraJemallocConfigureFlags " /usr/src/valkey/deps/Makefile; \
 	\
 	export BUILD_TLS=yes; \
+	\
 	make -C /usr/src/valkey -j "$(nproc)" all; \
 	make -C /usr/src/valkey install; \
 	\

--- a/8.0/debian/Dockerfile
+++ b/8.0/debian/Dockerfile
@@ -21,6 +21,7 @@ RUN set -eux; \
 		gcc \
 		libc6-dev \
 		libssl-dev \
+		libsystemd-dev \
 		make \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
@@ -55,6 +56,7 @@ RUN set -eux; \
 	grep -F "cd jemalloc && ./configure $extraJemallocConfigureFlags " /usr/src/valkey/deps/Makefile; \
 	\
 	export BUILD_TLS=yes; \
+	export USE_SYSTEMD=yes; \
 	make -C /usr/src/valkey -j "$(nproc)" all; \
 	make -C /usr/src/valkey install; \
 	\

--- a/8.1/alpine/Dockerfile
+++ b/8.1/alpine/Dockerfile
@@ -57,6 +57,7 @@ RUN set -eux; \
 	\
 	echo "Version 8.1.1 is 8.1 or higher - enabling USE_FAST_FLOAT"; \
 			export BUILD_TLS=yes USE_FAST_FLOAT=yes; \
+	\
 	make -C /usr/src/valkey -j "$(nproc)" all; \
 	make -C /usr/src/valkey install; \
 	\

--- a/8.1/debian/Dockerfile
+++ b/8.1/debian/Dockerfile
@@ -21,6 +21,7 @@ RUN set -eux; \
 		gcc \
 		libc6-dev \
 		libssl-dev \
+		libsystemd-dev \
 		make \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
@@ -59,6 +60,7 @@ RUN set -eux; \
 		apt-get install -y --no-install-recommends g++; \
 		rm -rf /var/lib/apt/lists/*; \
 		export BUILD_TLS=yes USE_FAST_FLOAT=yes; \
+	export USE_SYSTEMD=yes; \
 	make -C /usr/src/valkey -j "$(nproc)" all; \
 	make -C /usr/src/valkey install; \
 	\

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -32,6 +32,7 @@ RUN set -eux; \
 		gcc \
 		libc6-dev \
 		libssl-dev \
+		libsystemd-dev \
 		make \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
@@ -90,6 +91,11 @@ RUN set -eux; \
 	export BUILD_TLS=yes USE_FAST_FLOAT=yes; \
 {{ ) else ( -}}
 	export BUILD_TLS=yes; \
+{{ ) end -}}
+{{ if env.variant == "alpine" then ( -}}
+	\
+{{ ) else ( -}}
+	export USE_SYSTEMD=yes; \
 {{ ) end -}}
 	make -C /usr/src/valkey -j "$(nproc)" all; \
 	make -C /usr/src/valkey install; \

--- a/dockerhub-description-template.md
+++ b/dockerhub-description-template.md
@@ -78,6 +78,17 @@ Where `/myvalkey/conf/` is a local directory containing your `valkey.conf` file.
 
 The mapped directory should be writable, as depending on the configuration and mode of operation, Valkey may need to create additional configuration files or rewrite existing ones.
 
+## Systemd startup notification with Podman Quadlet
+
+Valkey supports startup notification to let systemd know it is ready to serve before its dependants are started. To use this, specify the following in your Quadlet service:
+
+```systemd
+[Container]
+Image=docker.io/valkey/valkey:latest
+Exec=valkey-server --supervised systemd
+Notify=true
+```
+
 # Image Variants
 
 The `valkey` images come in many flavors, each designed for a specific use case.

--- a/dockerhub-description.md
+++ b/dockerhub-description.md
@@ -86,6 +86,17 @@ Where `/myvalkey/conf/` is a local directory containing your `valkey.conf` file.
 
 The mapped directory should be writable, as depending on the configuration and mode of operation, Valkey may need to create additional configuration files or rewrite existing ones.
 
+## Systemd startup notification with Podman Quadlet
+
+Valkey supports startup notification to let systemd know it is ready to serve before its dependants are started. To use this, specify the following in your Quadlet service:
+
+```systemd
+[Container]
+Image=docker.io/valkey/valkey:latest
+Exec=valkey-server --supervised systemd
+Notify=true
+```
+
 # Image Variants
 
 The `valkey` images come in many flavors, each designed for a specific use case.

--- a/unstable/alpine/Dockerfile
+++ b/unstable/alpine/Dockerfile
@@ -57,6 +57,7 @@ RUN set -eux; \
 	\
 	echo "Unstable version detected — enabling USE_FAST_FLOAT"; \
 			export BUILD_TLS=yes USE_FAST_FLOAT=yes; \
+	\
 	make -C /usr/src/valkey -j "$(nproc)" all; \
 	make -C /usr/src/valkey install; \
 	\

--- a/unstable/debian/Dockerfile
+++ b/unstable/debian/Dockerfile
@@ -21,6 +21,7 @@ RUN set -eux; \
 		gcc \
 		libc6-dev \
 		libssl-dev \
+		libsystemd-dev \
 		make \
 	; \
 	rm -rf /var/lib/apt/lists/*; \
@@ -59,6 +60,7 @@ RUN set -eux; \
 		apt-get install -y --no-install-recommends g++; \
 		rm -rf /var/lib/apt/lists/*; \
 		export BUILD_TLS=yes USE_FAST_FLOAT=yes; \
+	export USE_SYSTEMD=yes; \
 	make -C /usr/src/valkey -j "$(nproc)" all; \
 	make -C /usr/src/valkey install; \
 	\


### PR DESCRIPTION
Debian minimal images already contains libsystemd, so take the opportunity to add systemd supervision support to them as well. This allow these images to work natively with Podman's sd_notify support, allowing them to be employed as a Quadlet or systemd service with reliable startup tracking.

![448594607-48b3f602-bc16-48df-a56a-b2412166fbc7](https://github.com/user-attachments/assets/506faea9-fc54-47e3-b0b4-51f2999d57aa)
