### PR TITLE
Fixes issue with Debian Trixie

### DIFF
--- a/9.0/debian/Dockerfile
+++ b/9.0/debian/Dockerfile
@@ -90,7 +90,7 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 # add tzdata explicitly for https://github.com/docker-library/valkey/issues/138 (see also https://bugs.debian.org/837060 and related)
 		tzdata \
-		libssl3 \
+		libssl3t64 \
 	; \
 	rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -165,7 +165,7 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 # add tzdata explicitly for https://github.com/docker-library/valkey/issues/138 (see also https://bugs.debian.org/837060 and related)
 		tzdata \
-		{{ if .debian.version == "trixie" then "libssl3t64" else "libssl3" end }} \
+		{{ if .debian.version != "bookworm" then "libssl3t64" else "libssl3" end }} \
 	; \
 	rm -rf /var/lib/apt/lists/*
 {{ ) end -}}

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -165,7 +165,7 @@ RUN set -eux; \
 	apt-get install -y --no-install-recommends \
 # add tzdata explicitly for https://github.com/docker-library/valkey/issues/138 (see also https://bugs.debian.org/837060 and related)
 		tzdata \
-		libssl3 \
+		{{ if .debian.version == "trixie" then "libssl3t64" else "libssl3" end }} \
 	; \
 	rm -rf /var/lib/apt/lists/*
 {{ ) end -}}


### PR DESCRIPTION
Trixie doesn't use libssl3 so I updated it to use libssl3t64. Should fix the build issue in https://github.com/valkey-io/valkey-container/actions/runs/16976281156/job/48126184364