### PR TITLE
fix reference link in Dockerfiles

### DIFF
--- a/.github/workflows/verify-templating.yml
+++ b/.github/workflows/verify-templating.yml
@@ -2,11 +2,15 @@ name: Verify Templating
 
 on:
   pull_request:
+    paths:
+      - "**/Dockerfile"
   push:
+    paths:
+      - "**/Dockerfile"
 
 defaults:
   run:
-    shell: 'bash -Eeuo pipefail -x {0}'
+    shell: "bash -Eeuo pipefail -x {0}"
 
 jobs:
   apply-templates:
@@ -24,7 +28,7 @@ jobs:
           echo "==== GIT STATUS END ===="
 
           git status
-          
+
           if [ -z "$status" ]; then
             echo "No changes detected."
           else

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -152,7 +152,7 @@ RUN set -eux; \
 {{ if env.variant == "alpine" then ( -}}
 RUN set -eux; \
 	apk add --no-cache \
-# add tzdata for https://github.com/docker-library/valkey/issues/138
+# add tzdata for https://github.com/docker-library/redis/issues/138
 		tzdata \
 		# add setpriv for step down from root.
 		setpriv \
@@ -163,7 +163,7 @@ RUN set -eux; \
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
-# add tzdata explicitly for https://github.com/docker-library/valkey/issues/138 (see also https://bugs.debian.org/837060 and related)
+# add tzdata explicitly for https://github.com/docker-library/redis/issues/138 (see also https://bugs.debian.org/837060 and related)
 		tzdata \
 		{{ if .debian.version != "bookworm" then "libssl3t64" else "libssl3" end }} \
 	; \


### PR DESCRIPTION
Renames all instances of 
https://github.com/docker-library/valkey/issues/138
to
https://github.com/docker-library/redis/issues/138

The former url is non-existent and could be misleading in the event docker-library were to package valkey.