### PR TITLE
feat: add `org.opencontainers.image.source` label to Dockerfile

### DIFF
--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -75,6 +75,8 @@ FROM base
 
 ENV VALKEY_VERSION 7.2.11
 
+LABEL org.opencontainers.image.source="https://github.com/valkey-io/valkey"
+
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN set -eux; \
 # alpine already has a gid 999, so we'll use the next id

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -75,6 +75,8 @@ FROM base
 
 ENV VALKEY_VERSION 7.2.11
 
+LABEL org.opencontainers.image.source="https://github.com/valkey-io/valkey"
+
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN set -eux; \
 	groupadd -r -g 999 valkey; \

--- a/8.0/alpine/Dockerfile
+++ b/8.0/alpine/Dockerfile
@@ -75,6 +75,8 @@ FROM base
 
 ENV VALKEY_VERSION 8.0.6
 
+LABEL org.opencontainers.image.source="https://github.com/valkey-io/valkey"
+
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN set -eux; \
 # alpine already has a gid 999, so we'll use the next id

--- a/8.0/debian/Dockerfile
+++ b/8.0/debian/Dockerfile
@@ -75,6 +75,8 @@ FROM base
 
 ENV VALKEY_VERSION 8.0.6
 
+LABEL org.opencontainers.image.source="https://github.com/valkey-io/valkey"
+
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN set -eux; \
 	groupadd -r -g 999 valkey; \

--- a/8.1/alpine/Dockerfile
+++ b/8.1/alpine/Dockerfile
@@ -76,6 +76,8 @@ FROM base
 
 ENV VALKEY_VERSION 8.1.4
 
+LABEL org.opencontainers.image.source="https://github.com/valkey-io/valkey"
+
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN set -eux; \
 # alpine already has a gid 999, so we'll use the next id

--- a/8.1/debian/Dockerfile
+++ b/8.1/debian/Dockerfile
@@ -79,6 +79,8 @@ FROM base
 
 ENV VALKEY_VERSION 8.1.4
 
+LABEL org.opencontainers.image.source="https://github.com/valkey-io/valkey"
+
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN set -eux; \
 	groupadd -r -g 999 valkey; \

--- a/9.0/alpine/Dockerfile
+++ b/9.0/alpine/Dockerfile
@@ -76,6 +76,8 @@ FROM base
 
 ENV VALKEY_VERSION 9.0.0-rc2
 
+LABEL org.opencontainers.image.source="https://github.com/valkey-io/valkey"
+
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN set -eux; \
 # alpine already has a gid 999, so we'll use the next id

--- a/9.0/debian/Dockerfile
+++ b/9.0/debian/Dockerfile
@@ -79,6 +79,8 @@ FROM base
 
 ENV VALKEY_VERSION 9.0.0-rc2
 
+LABEL org.opencontainers.image.source="https://github.com/valkey-io/valkey"
+
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN set -eux; \
 	groupadd -r -g 999 valkey; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -136,6 +136,8 @@ FROM base
 
 ENV VALKEY_VERSION {{ .version }}
 
+LABEL org.opencontainers.image.source="https://github.com/valkey-io/valkey"
+
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 {{ if env.variant == "alpine" then ( -}}
 RUN set -eux; \

--- a/unstable/alpine/Dockerfile
+++ b/unstable/alpine/Dockerfile
@@ -76,6 +76,8 @@ FROM base
 
 ENV VALKEY_VERSION unstable
 
+LABEL org.opencontainers.image.source="https://github.com/valkey-io/valkey"
+
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN set -eux; \
 # alpine already has a gid 999, so we'll use the next id

--- a/unstable/debian/Dockerfile
+++ b/unstable/debian/Dockerfile
@@ -79,6 +79,8 @@ FROM base
 
 ENV VALKEY_VERSION unstable
 
+LABEL org.opencontainers.image.source="https://github.com/valkey-io/valkey"
+
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN set -eux; \
 	groupadd -r -g 999 valkey; \


### PR DESCRIPTION
The `org.opencontainers.image.source` label can be used by tools or humans to find more information about this image.

[Renovatebot](https://docs.renovatebot.com) for examples uses it to retrieve [release notes](https://docs.renovatebot.com/modules/datasource/docker/#description). They will be displayed in the PRs created by renovate when it updates the valkey container image.