### PR TITLE
Update bashbrew action to v0.1.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
-      - uses: docker-library/bashbrew@v0.1.12
+      - uses: docker-library/bashbrew@v0.1.13
       - id: generate-jobs
         name: Generate Jobs
         run: |


### PR DESCRIPTION
## Overview

This Pull Request updates the version of the `docker-library/bashbrew` GitHub Action used in the workflow configuration.

## Problem

The previous version (`v0.1.12`) uses go1.20.14, encountered failures when trying to download necessary Go environment dependencies during the build process. Resolve this issue: https://github.com/actions/setup-go/issues/688.

Examples of these failures can be seen in the following CI runs: [Example 1](https://github.com/hanxizh9910/valkey-bundle/actions/runs/19871434410/job/56947948754) and [Example 2](https://github.com/roshkhatri/valkey-bundle/actions/runs/19912813038/job/57085170640).


## Solution

This PR updates the action to the latest available stable version, `v0.1.13`. 
