### PR TITLE
Add ppc64le arch support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
           push: ${{ env.PUBLISH_IMAGE }}
           tags: >-
             ${{ steps.modify_tags.outputs.docker_hub_tags }},${{ steps.modify_tags.outputs.ghcr_tags }},${{ steps.modify_tags.outputs.ecr_tags }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
           provenance: false
           load: false
 


### PR DESCRIPTION
This PR adds linux/ppc64le support.
I’m part of the IBM Power Ecosystem team. We have built and validated the image, and it works seamlessly on Power.
Making the container available would allow us to recommend it as an alternative to our customers.
Adding ppc64le support enables users to consume Valkey without maintaining custom builds.