### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,112 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM alpine:3.23 AS base
+
+FROM base AS build
+
+ENV VALKEY_DOWNLOAD_SHA 9cfbc5f32a2a6058ee0f8c532b9c4d24167cc49d719f091dd75f1bb8353a1fc5
+
+ADD "https://github.com/valkey-io/valkey/archive/refs/tags/9.0.1.tar.gz" /valkey.tar.gz
+
+RUN set -eux; \
+	\
+	apk add --no-cache \
+		coreutils \
+		dpkg-dev dpkg \
+		gcc \
+		g++ \
+		linux-headers \
+		make \
+		musl-dev \
+		openssl-dev \
+	; \
+	\
+			echo "$VALKEY_DOWNLOAD_SHA *valkey.tar.gz" | sha256sum -c -; \
+		\
+	mkdir -p /usr/src/valkey; \
+	tar -xzf valkey.tar.gz -C /usr/src/valkey --strip-components=1; \
+	rm valkey.tar.gz; \
+	\
+# disable Valkey protected mode [1] as it is unnecessary in context of Docker
+# (ports are not automatically exposed when running inside Docker, but rather explicitly by specifying -p / -P)
+	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *1 *,.*[)],$' /usr/src/valkey/src/config.c; \
+	sed -ri 's!^( *createBoolConfig[(]"protected-mode",.*, *)1( *,.*[)],)$!\10\2!' /usr/src/valkey/src/config.c; \
+	grep -E '^ *createBoolConfig[(]"protected-mode",.*, *0 *,.*[)],$' /usr/src/valkey/src/config.c; \
+# for future reference, we modify this directly in the source instead of just supplying a default configuration flag because apparently "if you specify any argument to valkey-server, [it assumes] you are going to specify everything"
+# (more exactly, this makes sure the default behavior of "save on SIGTERM" stays functional by default)
+	\
+# https://github.com/jemalloc/jemalloc/issues/467 -- we need to patch the "./configure" for the bundled jemalloc to match how Debian compiles, for compatibility
+# (also, we do cross-builds, so we need to embed the appropriate "--build=xxx" values to that "./configure" invocation)
+	gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+	extraJemallocConfigureFlags="--build=$gnuArch"; \
+# https://salsa.debian.org/debian/jemalloc/-/blob/c0a88c37a551be7d12e4863435365c9a6a51525f/debian/rules#L8-23
+	dpkgArch="$(dpkg --print-architecture)"; \
+	case "${dpkgArch##*-}" in \
+		amd64 | i386 | x32) extraJemallocConfigureFlags="$extraJemallocConfigureFlags --with-lg-page=12" ;; \
+		*) extraJemallocConfigureFlags="$extraJemallocConfigureFlags --with-lg-page=16" ;; \
+	esac; \
+	extraJemallocConfigureFlags="$extraJemallocConfigureFlags --with-lg-hugepage=21"; \
+	grep -F 'cd jemalloc && ./configure ' /usr/src/valkey/deps/Makefile; \
+	sed -ri 's!cd jemalloc && ./configure !&'"$extraJemallocConfigureFlags"' !' /usr/src/valkey/deps/Makefile; \
+	grep -F "cd jemalloc && ./configure $extraJemallocConfigureFlags " /usr/src/valkey/deps/Makefile; \
+	\
+	echo "Version 9.0.1 is 8.1 or higher - enabling USE_FAST_FLOAT"; \
+			export BUILD_TLS=yes USE_FAST_FLOAT=yes; \
+	\
+	make -C /usr/src/valkey -j "$(nproc)" all; \
+	make -C /usr/src/valkey install; \
+	\
+	serverMd5="$(md5sum /usr/local/bin/valkey-server | cut -d' ' -f1)"; export serverMd5; \
+	find /usr/local/bin/valkey* -maxdepth 0 \
+		-type f -not -name valkey-server \
+		-exec sh -eux -c ' \
+			md5="$(md5sum "$1" | cut -d" " -f1)"; \
+			test "$md5" = "$serverMd5"; \
+		' -- '{}' ';' \
+		-exec ln -svfT 'valkey-server' '{}' ';' \
+	; \
+	\
+	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"9.0.1","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.0.1?os_name=alpine&os_version=3.23"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+
+FROM base
+
+ENV VALKEY_VERSION 9.0.1
+
+LABEL org.opencontainers.image.source="https://github.com/valkey-io/valkey"
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN set -eux; \
+# alpine already has a gid 999, so we'll use the next id
+	addgroup -S -g 1000 valkey; \
+	adduser -S -G valkey -u 999 valkey
+
+# runtime dependencies
+RUN set -eux; \
+	apk add --no-cache \
+# add tzdata for https://github.com/docker-library/redis/issues/138
+		tzdata \
+		# add setpriv for step down from root.
+		setpriv \
+		openssl \
+		libgcc \
+	;
+
+# Install valkey built earlier
+COPY --from=build /usr/local /usr/local
+RUN mkdir /data && \
+	chown valkey:valkey /data && \
+	mkdir -p /run/valkey && \
+	chown valkey:valkey /run/valkey && \
+	valkey-cli --version && \
+	valkey-server --version
+WORKDIR /data
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 6379
+CMD ["valkey-server"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+# or first arg is `something.conf`
+if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
+	set -- valkey-server "$@"
+fi
+
+# allow the container to be started with `--user`
+if [ "$1" = 'valkey-server' ]; then
+    if [ "$(id -u)" = '0' ]; then
+        find . \! -user valkey -exec chown valkey '{}' +
+        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+    else
+        if [ ! -w . ]; then
+            echo >&2 "error: directory is not writable by current user ($(id -u))"
+            echo >&2 "  Check mount permissions or run as root to allow chown"
+            exit 1
+        fi
+    fi
+fi
+
+
+# set an appropriate umask (if one isn't set already)
+um="$(umask)"
+if [ "$um" = '0022' ]; then
+	umask 0077
+fi
+
+exec "$@" $VALKEY_EXTRA_FLAGS


### PR DESCRIPTION
Update docker-entrypoint.sh due to permission issues when starting valkey-container.
In the docker-entrypoint.sh code, we need logic to check if the user has at least write permission to the /data directory even if the user is not root.
When the valkey container is terminated, it tries to take an RDB snapshot to save data, but the problem occurs because the current container User (1000) does not have write permission to the mounted /data folder.

"Failed opening the temp RDB file temp-1.rdb (in server root dir /data) for saving: Permission denied"

![1](https://github.com/user-attachments/assets/c260fa4a-d095-4cb9-a2eb-853854301d94)


When starting a container, we added logic to check in advance whether the current folder has write permission when not root, and confirmed through testing that it terminates gracefully.
![2](https://github.com/user-attachments/assets/7f54777c-c93f-4b29-b4c1-117054568392)


Modified the code to follow the Fail Fast principle.
