### PR TITLE
updated docker-entrypoint.sh

### DIFF
--- a/7.2/alpine/docker-entrypoint.sh
+++ b/7.2/alpine/docker-entrypoint.sh
@@ -8,9 +8,17 @@ if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
 fi
 
 # allow the container to be started with `--user`
-if [ "$1" = 'valkey-server' -a "$(id -u)" = '0' ]; then
-	find . \! -user valkey -exec chown valkey '{}' +
-	exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+if [ "$1" = 'valkey-server' ]; then
+    if [ "$(id -u)" = '0' ]; then
+        find . \! -user valkey -exec chown valkey '{}' +
+        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+    else
+        if [ ! -w . ]; then
+            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+            echo >&2 "  Check mount permissions or run as root to allow chown"
+            exit 1
+        fi
+    fi
 fi
 
 # set an appropriate umask (if one isn't set already)

--- a/7.2/alpine/docker-entrypoint.sh
+++ b/7.2/alpine/docker-entrypoint.sh
@@ -9,16 +9,16 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'valkey-server' ]; then
-    if [ "$(id -u)" = '0' ]; then
-        find . \! -user valkey -exec chown valkey '{}' +
-        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
-    else
-        if [ ! -w . ]; then
-            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-            echo >&2 "  Check mount permissions or run as root to allow chown"
-            exit 1
-        fi
-    fi
+	if [ "$(id -u)" = '0' ]; then
+		find . \! -user valkey -exec chown valkey '{}' +
+		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+	else
+		if [ ! -w . ]; then
+			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  Check mount permissions or run as root to allow chown"
+			exit 1
+		fi
+	fi
 fi
 
 # set an appropriate umask (if one isn't set already)

--- a/7.2/debian/docker-entrypoint.sh
+++ b/7.2/debian/docker-entrypoint.sh
@@ -8,9 +8,17 @@ if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
 fi
 
 # allow the container to be started with `--user`
-if [ "$1" = 'valkey-server' -a "$(id -u)" = '0' ]; then
-	find . \! -user valkey -exec chown valkey '{}' +
-	exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+if [ "$1" = 'valkey-server' ]; then
+    if [ "$(id -u)" = '0' ]; then
+        find . \! -user valkey -exec chown valkey '{}' +
+        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+    else
+        if [ ! -w . ]; then
+            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+            echo >&2 "  Check mount permissions or run as root to allow chown"
+            exit 1
+        fi
+    fi
 fi
 
 # set an appropriate umask (if one isn't set already)

--- a/7.2/debian/docker-entrypoint.sh
+++ b/7.2/debian/docker-entrypoint.sh
@@ -9,16 +9,16 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'valkey-server' ]; then
-    if [ "$(id -u)" = '0' ]; then
-        find . \! -user valkey -exec chown valkey '{}' +
-        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
-    else
-        if [ ! -w . ]; then
-            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-            echo >&2 "  Check mount permissions or run as root to allow chown"
-            exit 1
-        fi
-    fi
+	if [ "$(id -u)" = '0' ]; then
+		find . \! -user valkey -exec chown valkey '{}' +
+		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+	else
+		if [ ! -w . ]; then
+			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  Check mount permissions or run as root to allow chown"
+			exit 1
+		fi
+	fi
 fi
 
 # set an appropriate umask (if one isn't set already)

--- a/8.0/alpine/docker-entrypoint.sh
+++ b/8.0/alpine/docker-entrypoint.sh
@@ -8,9 +8,17 @@ if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
 fi
 
 # allow the container to be started with `--user`
-if [ "$1" = 'valkey-server' -a "$(id -u)" = '0' ]; then
-	find . \! -user valkey -exec chown valkey '{}' +
-	exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+if [ "$1" = 'valkey-server' ]; then
+    if [ "$(id -u)" = '0' ]; then
+        find . \! -user valkey -exec chown valkey '{}' +
+        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+    else
+        if [ ! -w . ]; then
+            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+            echo >&2 "  Check mount permissions or run as root to allow chown"
+            exit 1
+        fi
+    fi
 fi
 
 # set an appropriate umask (if one isn't set already)

--- a/8.0/alpine/docker-entrypoint.sh
+++ b/8.0/alpine/docker-entrypoint.sh
@@ -9,16 +9,16 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'valkey-server' ]; then
-    if [ "$(id -u)" = '0' ]; then
-        find . \! -user valkey -exec chown valkey '{}' +
-        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
-    else
-        if [ ! -w . ]; then
-            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-            echo >&2 "  Check mount permissions or run as root to allow chown"
-            exit 1
-        fi
-    fi
+	if [ "$(id -u)" = '0' ]; then
+		find . \! -user valkey -exec chown valkey '{}' +
+		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+	else
+		if [ ! -w . ]; then
+			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  Check mount permissions or run as root to allow chown"
+			exit 1
+		fi
+	fi
 fi
 
 # set an appropriate umask (if one isn't set already)

--- a/8.0/debian/docker-entrypoint.sh
+++ b/8.0/debian/docker-entrypoint.sh
@@ -8,9 +8,17 @@ if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
 fi
 
 # allow the container to be started with `--user`
-if [ "$1" = 'valkey-server' -a "$(id -u)" = '0' ]; then
-	find . \! -user valkey -exec chown valkey '{}' +
-	exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+if [ "$1" = 'valkey-server' ]; then
+    if [ "$(id -u)" = '0' ]; then
+        find . \! -user valkey -exec chown valkey '{}' +
+        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+    else
+        if [ ! -w . ]; then
+            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+            echo >&2 "  Check mount permissions or run as root to allow chown"
+            exit 1
+        fi
+    fi
 fi
 
 # set an appropriate umask (if one isn't set already)

--- a/8.0/debian/docker-entrypoint.sh
+++ b/8.0/debian/docker-entrypoint.sh
@@ -9,16 +9,16 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'valkey-server' ]; then
-    if [ "$(id -u)" = '0' ]; then
-        find . \! -user valkey -exec chown valkey '{}' +
-        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
-    else
-        if [ ! -w . ]; then
-            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-            echo >&2 "  Check mount permissions or run as root to allow chown"
-            exit 1
-        fi
-    fi
+	if [ "$(id -u)" = '0' ]; then
+		find . \! -user valkey -exec chown valkey '{}' +
+		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+	else
+		if [ ! -w . ]; then
+			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  Check mount permissions or run as root to allow chown"
+			exit 1
+		fi
+	fi
 fi
 
 # set an appropriate umask (if one isn't set already)

--- a/8.1/alpine/docker-entrypoint.sh
+++ b/8.1/alpine/docker-entrypoint.sh
@@ -8,9 +8,17 @@ if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
 fi
 
 # allow the container to be started with `--user`
-if [ "$1" = 'valkey-server' -a "$(id -u)" = '0' ]; then
-	find . \! -user valkey -exec chown valkey '{}' +
-	exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+if [ "$1" = 'valkey-server' ]; then
+    if [ "$(id -u)" = '0' ]; then
+        find . \! -user valkey -exec chown valkey '{}' +
+        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+    else
+        if [ ! -w . ]; then
+            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+            echo >&2 "  Check mount permissions or run as root to allow chown"
+            exit 1
+        fi
+    fi
 fi
 
 # set an appropriate umask (if one isn't set already)

--- a/8.1/alpine/docker-entrypoint.sh
+++ b/8.1/alpine/docker-entrypoint.sh
@@ -9,16 +9,16 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'valkey-server' ]; then
-    if [ "$(id -u)" = '0' ]; then
-        find . \! -user valkey -exec chown valkey '{}' +
-        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
-    else
-        if [ ! -w . ]; then
-            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-            echo >&2 "  Check mount permissions or run as root to allow chown"
-            exit 1
-        fi
-    fi
+	if [ "$(id -u)" = '0' ]; then
+		find . \! -user valkey -exec chown valkey '{}' +
+		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+	else
+		if [ ! -w . ]; then
+			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  Check mount permissions or run as root to allow chown"
+			exit 1
+		fi
+	fi
 fi
 
 # set an appropriate umask (if one isn't set already)

--- a/8.1/debian/docker-entrypoint.sh
+++ b/8.1/debian/docker-entrypoint.sh
@@ -8,9 +8,17 @@ if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
 fi
 
 # allow the container to be started with `--user`
-if [ "$1" = 'valkey-server' -a "$(id -u)" = '0' ]; then
-	find . \! -user valkey -exec chown valkey '{}' +
-	exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+if [ "$1" = 'valkey-server' ]; then
+    if [ "$(id -u)" = '0' ]; then
+        find . \! -user valkey -exec chown valkey '{}' +
+        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+    else
+        if [ ! -w . ]; then
+            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+            echo >&2 "  Check mount permissions or run as root to allow chown"
+            exit 1
+        fi
+    fi
 fi
 
 # set an appropriate umask (if one isn't set already)

--- a/8.1/debian/docker-entrypoint.sh
+++ b/8.1/debian/docker-entrypoint.sh
@@ -9,16 +9,16 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'valkey-server' ]; then
-    if [ "$(id -u)" = '0' ]; then
-        find . \! -user valkey -exec chown valkey '{}' +
-        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
-    else
-        if [ ! -w . ]; then
-            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-            echo >&2 "  Check mount permissions or run as root to allow chown"
-            exit 1
-        fi
-    fi
+	if [ "$(id -u)" = '0' ]; then
+		find . \! -user valkey -exec chown valkey '{}' +
+		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+	else
+		if [ ! -w . ]; then
+			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  Check mount permissions or run as root to allow chown"
+			exit 1
+		fi
+	fi
 fi
 
 # set an appropriate umask (if one isn't set already)

--- a/9.0/alpine/docker-entrypoint.sh
+++ b/9.0/alpine/docker-entrypoint.sh
@@ -8,10 +8,19 @@ if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
 fi
 
 # allow the container to be started with `--user`
-if [ "$1" = 'valkey-server' -a "$(id -u)" = '0' ]; then
-	find . \! -user valkey -exec chown valkey '{}' +
-	exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+if [ "$1" = 'valkey-server' ]; then
+    if [ "$(id -u)" = '0' ]; then
+        find . \! -user valkey -exec chown valkey '{}' +
+        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+    else
+        if [ ! -w . ]; then
+            echo >&2 "error: directory is not writable by current user ($(id -u))"
+            echo >&2 "  Check mount permissions or run as root to allow chown"
+            exit 1
+        fi
+    fi
 fi
+
 
 # set an appropriate umask (if one isn't set already)
 um="$(umask)"

--- a/9.0/alpine/docker-entrypoint.sh
+++ b/9.0/alpine/docker-entrypoint.sh
@@ -14,13 +14,12 @@ if [ "$1" = 'valkey-server' ]; then
         exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
     else
         if [ ! -w . ]; then
-            echo >&2 "error: directory is not writable by current user ($(id -u))"
+            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
             echo >&2 "  Check mount permissions or run as root to allow chown"
             exit 1
         fi
     fi
 fi
-
 
 # set an appropriate umask (if one isn't set already)
 um="$(umask)"

--- a/9.0/alpine/docker-entrypoint.sh
+++ b/9.0/alpine/docker-entrypoint.sh
@@ -9,16 +9,16 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'valkey-server' ]; then
-    if [ "$(id -u)" = '0' ]; then
-        find . \! -user valkey -exec chown valkey '{}' +
-        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
-    else
-        if [ ! -w . ]; then
-            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-            echo >&2 "  Check mount permissions or run as root to allow chown"
-            exit 1
-        fi
-    fi
+	if [ "$(id -u)" = '0' ]; then
+		find . \! -user valkey -exec chown valkey '{}' +
+		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+	else
+		if [ ! -w . ]; then
+			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  Check mount permissions or run as root to allow chown"
+			exit 1
+		fi
+	fi
 fi
 
 # set an appropriate umask (if one isn't set already)

--- a/9.0/debian/docker-entrypoint.sh
+++ b/9.0/debian/docker-entrypoint.sh
@@ -8,9 +8,17 @@ if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
 fi
 
 # allow the container to be started with `--user`
-if [ "$1" = 'valkey-server' -a "$(id -u)" = '0' ]; then
-	find . \! -user valkey -exec chown valkey '{}' +
-	exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+if [ "$1" = 'valkey-server' ]; then
+    if [ "$(id -u)" = '0' ]; then
+        find . \! -user valkey -exec chown valkey '{}' +
+        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+    else
+        if [ ! -w . ]; then
+            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+            echo >&2 "  Check mount permissions or run as root to allow chown"
+            exit 1
+        fi
+    fi
 fi
 
 # set an appropriate umask (if one isn't set already)

--- a/9.0/debian/docker-entrypoint.sh
+++ b/9.0/debian/docker-entrypoint.sh
@@ -9,16 +9,16 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'valkey-server' ]; then
-    if [ "$(id -u)" = '0' ]; then
-        find . \! -user valkey -exec chown valkey '{}' +
-        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
-    else
-        if [ ! -w . ]; then
-            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-            echo >&2 "  Check mount permissions or run as root to allow chown"
-            exit 1
-        fi
-    fi
+	if [ "$(id -u)" = '0' ]; then
+		find . \! -user valkey -exec chown valkey '{}' +
+		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+	else
+		if [ ! -w . ]; then
+			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  Check mount permissions or run as root to allow chown"
+			exit 1
+		fi
+	fi
 fi
 
 # set an appropriate umask (if one isn't set already)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,9 +8,17 @@ if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
 fi
 
 # allow the container to be started with `--user`
-if [ "$1" = 'valkey-server' -a "$(id -u)" = '0' ]; then
-	find . \! -user valkey -exec chown valkey '{}' +
-	exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+if [ "$1" = 'valkey-server' ]; then
+    if [ "$(id -u)" = '0' ]; then
+        find . \! -user valkey -exec chown valkey '{}' +
+        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+    else
+        if [ ! -w . ]; then
+            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+            echo >&2 "  Check mount permissions or run as root to allow chown"
+            exit 1
+        fi
+    fi
 fi
 
 # set an appropriate umask (if one isn't set already)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,16 +9,16 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'valkey-server' ]; then
-    if [ "$(id -u)" = '0' ]; then
-        find . \! -user valkey -exec chown valkey '{}' +
-        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
-    else
-        if [ ! -w . ]; then
-            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-            echo >&2 "  Check mount permissions or run as root to allow chown"
-            exit 1
-        fi
-    fi
+	if [ "$(id -u)" = '0' ]; then
+		find . \! -user valkey -exec chown valkey '{}' +
+		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+	else
+		if [ ! -w . ]; then
+			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  Check mount permissions or run as root to allow chown"
+			exit 1
+		fi
+	fi
 fi
 
 # set an appropriate umask (if one isn't set already)

--- a/unstable/alpine/docker-entrypoint.sh
+++ b/unstable/alpine/docker-entrypoint.sh
@@ -8,9 +8,17 @@ if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
 fi
 
 # allow the container to be started with `--user`
-if [ "$1" = 'valkey-server' -a "$(id -u)" = '0' ]; then
-	find . \! -user valkey -exec chown valkey '{}' +
-	exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+if [ "$1" = 'valkey-server' ]; then
+    if [ "$(id -u)" = '0' ]; then
+        find . \! -user valkey -exec chown valkey '{}' +
+        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+    else
+        if [ ! -w . ]; then
+            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+            echo >&2 "  Check mount permissions or run as root to allow chown"
+            exit 1
+        fi
+    fi
 fi
 
 # set an appropriate umask (if one isn't set already)

--- a/unstable/alpine/docker-entrypoint.sh
+++ b/unstable/alpine/docker-entrypoint.sh
@@ -9,16 +9,16 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'valkey-server' ]; then
-    if [ "$(id -u)" = '0' ]; then
-        find . \! -user valkey -exec chown valkey '{}' +
-        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
-    else
-        if [ ! -w . ]; then
-            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-            echo >&2 "  Check mount permissions or run as root to allow chown"
-            exit 1
-        fi
-    fi
+	if [ "$(id -u)" = '0' ]; then
+		find . \! -user valkey -exec chown valkey '{}' +
+		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+	else
+		if [ ! -w . ]; then
+			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  Check mount permissions or run as root to allow chown"
+			exit 1
+		fi
+	fi
 fi
 
 # set an appropriate umask (if one isn't set already)

--- a/unstable/debian/docker-entrypoint.sh
+++ b/unstable/debian/docker-entrypoint.sh
@@ -8,9 +8,17 @@ if [ "${1#-}" != "$1" ] || [ "${1%.conf}" != "$1" ]; then
 fi
 
 # allow the container to be started with `--user`
-if [ "$1" = 'valkey-server' -a "$(id -u)" = '0' ]; then
-	find . \! -user valkey -exec chown valkey '{}' +
-	exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+if [ "$1" = 'valkey-server' ]; then
+    if [ "$(id -u)" = '0' ]; then
+        find . \! -user valkey -exec chown valkey '{}' +
+        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+    else
+        if [ ! -w . ]; then
+            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+            echo >&2 "  Check mount permissions or run as root to allow chown"
+            exit 1
+        fi
+    fi
 fi
 
 # set an appropriate umask (if one isn't set already)

--- a/unstable/debian/docker-entrypoint.sh
+++ b/unstable/debian/docker-entrypoint.sh
@@ -9,16 +9,16 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'valkey-server' ]; then
-    if [ "$(id -u)" = '0' ]; then
-        find . \! -user valkey -exec chown valkey '{}' +
-        exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
-    else
-        if [ ! -w . ]; then
-            echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-            echo >&2 "  Check mount permissions or run as root to allow chown"
-            exit 1
-        fi
-    fi
+	if [ "$(id -u)" = '0' ]; then
+		find . \! -user valkey -exec chown valkey '{}' +
+		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
+	else
+		if [ ! -w . ]; then
+			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  Check mount permissions or run as root to allow chown"
+			exit 1
+		fi
+	fi
 fi
 
 # set an appropriate umask (if one isn't set already)


### PR DESCRIPTION
Update docker-entrypoint.sh due to permission issues when starting valkey-container.
In the docker-entrypoint.sh code, we need logic to check if the user has at least write permission to the /data directory even if the user is not root.
When the valkey container is terminated, it tries to take an RDB snapshot to save data, but the problem occurs because the current container User (1000) does not have write permission to the mounted /data folder.

"Failed opening the temp RDB file temp-1.rdb (in server root dir /data) for saving: Permission denied"
![1](https://github.com/user-attachments/assets/4920890a-b3df-4ceb-90cd-97ec5bfc887c)


When starting a container, we added logic to check in advance whether the current folder has write permission when not root, and confirmed through testing that it terminates gracefully.
![2](https://github.com/user-attachments/assets/ae4a9a12-98f8-421f-92e5-729aaf389232)

Modified the code to follow the "Fail Fast" principle.