### PR TITLE
Add VOLUME /data directive to all Dockerfiles

### DIFF
--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -102,6 +102,7 @@ RUN mkdir /data && \
 	chown valkey:valkey /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
+VOLUME /data
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -100,6 +100,7 @@ RUN mkdir /data && \
 	chown valkey:valkey /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
+VOLUME /data
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/8.0/alpine/Dockerfile
+++ b/8.0/alpine/Dockerfile
@@ -102,6 +102,7 @@ RUN mkdir /data && \
 	chown valkey:valkey /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
+VOLUME /data
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/8.0/debian/Dockerfile
+++ b/8.0/debian/Dockerfile
@@ -100,6 +100,7 @@ RUN mkdir /data && \
 	chown valkey:valkey /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
+VOLUME /data
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/8.1/alpine/Dockerfile
+++ b/8.1/alpine/Dockerfile
@@ -103,6 +103,7 @@ RUN mkdir /data && \
 	chown valkey:valkey /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
+VOLUME /data
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/8.1/debian/Dockerfile
+++ b/8.1/debian/Dockerfile
@@ -104,6 +104,7 @@ RUN mkdir /data && \
 	chown valkey:valkey /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
+VOLUME /data
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/9.0/alpine/Dockerfile
+++ b/9.0/alpine/Dockerfile
@@ -103,6 +103,7 @@ RUN mkdir /data && \
 	chown valkey:valkey /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
+VOLUME /data
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/9.0/debian/Dockerfile
+++ b/9.0/debian/Dockerfile
@@ -104,6 +104,7 @@ RUN mkdir /data && \
 	chown valkey:valkey /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
+VOLUME /data
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -180,6 +180,7 @@ RUN mkdir /data && \
 	chown valkey:valkey /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
+VOLUME /data
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/unstable/alpine/Dockerfile
+++ b/unstable/alpine/Dockerfile
@@ -103,6 +103,7 @@ RUN mkdir /data && \
 	chown valkey:valkey /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
+VOLUME /data
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/unstable/debian/Dockerfile
+++ b/unstable/debian/Dockerfile
@@ -104,6 +104,7 @@ RUN mkdir /data && \
 	chown valkey:valkey /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
+VOLUME /data
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/


### PR DESCRIPTION
- Add VOLUME /data to all versions (7.2, 8.0, 8.1, 9.0, unstable)
- Add for both alpine and debian variants
- Align with Redis Dockerfile structure
- Fixes missing volume declaration causing docker volume mount issues