### PR TITLE
Fix writable check warning

### DIFF
--- a/.test/config.sh
+++ b/.test/config.sh
@@ -6,5 +6,6 @@ imageTests+=(
 		valkey-basics-tls
 		valkey-basics-config
 		valkey-basics-persistent
+		valkey-readonly-data
 	'
 )

--- a/.test/tests/valkey-readonly-data/run.sh
+++ b/.test/tests/valkey-readonly-data/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+image="$1"
+
+# Build a test image that runs as non-root with a read-only /data
+testImage="$("$dir/../image-name.sh" librarytest/valkey-readonly-data "$image")"
+"$dir/../docker-build.sh" "$dir" "$testImage" <<-EOD
+	FROM $image
+	RUN chmod 555 /data
+	USER valkey
+	CMD ["valkey-server", "--save", "", "--appendonly", "no"]
+EOD
+
+network="valkey-network-$RANDOM-$RANDOM"
+docker network create "$network" >/dev/null
+
+cname="valkey-container-$RANDOM-$RANDOM"
+cid="$(docker run -d --name "$cname" --network "$network" "$testImage")"
+
+trap "docker rm -vf '$cid' >/dev/null; docker network rm '$network' >/dev/null" EXIT
+
+# Verify the container starts and responds despite /data being read-only
+valkey-cli() {
+	docker run --rm -i \
+		--network "$network" \
+		--entrypoint valkey-cli \
+		"$image" \
+		-h "$cname" \
+		"$@"
+}
+
+. "$dir/../../retry.sh" --tries 20 '[ "$(valkey-cli ping)" = "PONG" ]'
+
+# Verify the warning was emitted
+logs="$(docker logs "$cid" 2>&1)"
+if ! echo "$logs" | grep -q "warning: directory"; then
+	echo >&2 "ERROR: expected writable warning in logs but did not find it"
+	exit 1
+fi
+
+echo "PASS: container started with read-only /data and emitted warning"

--- a/7.2/alpine/docker-entrypoint.sh
+++ b/7.2/alpine/docker-entrypoint.sh
@@ -14,9 +14,8 @@ if [ "$1" = 'valkey-server' ]; then
 		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
 	else
 		if [ ! -w . ]; then
-			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-			echo >&2 "  Check mount permissions or run as root to allow chown"
-			exit 1
+			echo >&2 "warning: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  If persistence is enabled, this will cause errors. Check mount permissions or run as root to allow chown"
 		fi
 	fi
 fi

--- a/7.2/debian/docker-entrypoint.sh
+++ b/7.2/debian/docker-entrypoint.sh
@@ -14,9 +14,8 @@ if [ "$1" = 'valkey-server' ]; then
 		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
 	else
 		if [ ! -w . ]; then
-			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-			echo >&2 "  Check mount permissions or run as root to allow chown"
-			exit 1
+			echo >&2 "warning: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  If persistence is enabled, this will cause errors. Check mount permissions or run as root to allow chown"
 		fi
 	fi
 fi

--- a/8.0/alpine/docker-entrypoint.sh
+++ b/8.0/alpine/docker-entrypoint.sh
@@ -14,9 +14,8 @@ if [ "$1" = 'valkey-server' ]; then
 		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
 	else
 		if [ ! -w . ]; then
-			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-			echo >&2 "  Check mount permissions or run as root to allow chown"
-			exit 1
+			echo >&2 "warning: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  If persistence is enabled, this will cause errors. Check mount permissions or run as root to allow chown"
 		fi
 	fi
 fi

--- a/8.0/debian/docker-entrypoint.sh
+++ b/8.0/debian/docker-entrypoint.sh
@@ -14,9 +14,8 @@ if [ "$1" = 'valkey-server' ]; then
 		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
 	else
 		if [ ! -w . ]; then
-			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-			echo >&2 "  Check mount permissions or run as root to allow chown"
-			exit 1
+			echo >&2 "warning: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  If persistence is enabled, this will cause errors. Check mount permissions or run as root to allow chown"
 		fi
 	fi
 fi

--- a/8.1/alpine/docker-entrypoint.sh
+++ b/8.1/alpine/docker-entrypoint.sh
@@ -14,9 +14,8 @@ if [ "$1" = 'valkey-server' ]; then
 		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
 	else
 		if [ ! -w . ]; then
-			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-			echo >&2 "  Check mount permissions or run as root to allow chown"
-			exit 1
+			echo >&2 "warning: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  If persistence is enabled, this will cause errors. Check mount permissions or run as root to allow chown"
 		fi
 	fi
 fi

--- a/8.1/debian/docker-entrypoint.sh
+++ b/8.1/debian/docker-entrypoint.sh
@@ -14,9 +14,8 @@ if [ "$1" = 'valkey-server' ]; then
 		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
 	else
 		if [ ! -w . ]; then
-			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-			echo >&2 "  Check mount permissions or run as root to allow chown"
-			exit 1
+			echo >&2 "warning: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  If persistence is enabled, this will cause errors. Check mount permissions or run as root to allow chown"
 		fi
 	fi
 fi

--- a/9.0/alpine/docker-entrypoint.sh
+++ b/9.0/alpine/docker-entrypoint.sh
@@ -14,9 +14,8 @@ if [ "$1" = 'valkey-server' ]; then
 		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
 	else
 		if [ ! -w . ]; then
-			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-			echo >&2 "  Check mount permissions or run as root to allow chown"
-			exit 1
+			echo >&2 "warning: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  If persistence is enabled, this will cause errors. Check mount permissions or run as root to allow chown"
 		fi
 	fi
 fi

--- a/9.0/debian/docker-entrypoint.sh
+++ b/9.0/debian/docker-entrypoint.sh
@@ -14,9 +14,8 @@ if [ "$1" = 'valkey-server' ]; then
 		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
 	else
 		if [ ! -w . ]; then
-			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-			echo >&2 "  Check mount permissions or run as root to allow chown"
-			exit 1
+			echo >&2 "warning: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  If persistence is enabled, this will cause errors. Check mount permissions or run as root to allow chown"
 		fi
 	fi
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,9 +14,8 @@ if [ "$1" = 'valkey-server' ]; then
 		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
 	else
 		if [ ! -w . ]; then
-			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-			echo >&2 "  Check mount permissions or run as root to allow chown"
-			exit 1
+			echo >&2 "warning: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  If persistence is enabled, this will cause errors. Check mount permissions or run as root to allow chown"
 		fi
 	fi
 fi

--- a/unstable/alpine/docker-entrypoint.sh
+++ b/unstable/alpine/docker-entrypoint.sh
@@ -14,9 +14,8 @@ if [ "$1" = 'valkey-server' ]; then
 		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
 	else
 		if [ ! -w . ]; then
-			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-			echo >&2 "  Check mount permissions or run as root to allow chown"
-			exit 1
+			echo >&2 "warning: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  If persistence is enabled, this will cause errors. Check mount permissions or run as root to allow chown"
 		fi
 	fi
 fi

--- a/unstable/debian/docker-entrypoint.sh
+++ b/unstable/debian/docker-entrypoint.sh
@@ -14,9 +14,8 @@ if [ "$1" = 'valkey-server' ]; then
 		exec setpriv --reuid=valkey --regid=valkey --clear-groups -- "$0" "$@"
 	else
 		if [ ! -w . ]; then
-			echo >&2 "error: directory '$(pwd)' is not writable by current user ($(id -u))"
-			echo >&2 "  Check mount permissions or run as root to allow chown"
-			exit 1
+			echo >&2 "warning: directory '$(pwd)' is not writable by current user ($(id -u))"
+			echo >&2 "  If persistence is enabled, this will cause errors. Check mount permissions or run as root to allow chown"
 		fi
 	fi
 fi


### PR DESCRIPTION
Fixes #130

PR #119 added a writability check for /data that exits with an error when running as a non-root user. This
breaks valid configurations where /data doesn't need to be writable e.g., Sentinel mode, persistence disabled,
or dir configured elsewhere.

This PR changes the check from a hard exit 1 to a warning. Users still get a clear message about potential
permission issues, but the container no longer refuses to start for setups that worked fine before.

Also adds a test that verifies the container starts successfully with a read-only /data when persistence is
disabled.

The entrypoint doesn't have enough context to know which case it's in. It runs before
Valkey parses its config, so it can't know if persistence is enabled or where dir points. It making a decision without enough information.

`fail-fast` idea was useful but cannot have breaking changes. A warning is the right middle ground, it
surfaces the potential problem for the cases where it matters, without breaking the cases where it doesn't. The
user who actually needs write access will still see the warning and get the valkey level error, so they won't
miss it.