### PR TITLE
Fix permission denied with --user flag

### DIFF
--- a/.test/config.sh
+++ b/.test/config.sh
@@ -7,5 +7,6 @@ imageTests+=(
 		valkey-basics-config
 		valkey-basics-persistent
 		valkey-readonly-data
+		valkey-user-flag
 	'
 )

--- a/.test/tests/valkey-user-flag/run.sh
+++ b/.test/tests/valkey-user-flag/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+image="$1"
+
+network="valkey-network-$RANDOM-$RANDOM"
+docker network create "$network" >/dev/null
+
+cname="valkey-container-$RANDOM-$RANDOM"
+# Run as a non-default user (uid 1000) to test --user flag support
+cid="$(docker run -d --name "$cname" --network "$network" --user 1000:1000 "$image")"
+
+trap "docker rm -vf '$cid' >/dev/null; docker network rm '$network' >/dev/null" EXIT
+
+valkey-cli() {
+  docker run --rm -i \
+    --network "$network" \
+    --entrypoint valkey-cli \
+    "$image" \
+    -h "$cname" \
+    "$@"
+}
+
+. "$dir/../../retry.sh" --tries 20 '[ "$(valkey-cli ping)" = "PONG" ]'
+
+# Verify we can write data (proves /data is writable by non-default user)
+[ "$(valkey-cli set mykey somevalue)" = "OK" ]
+[ "$(valkey-cli get mykey)" = "somevalue" ]

--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -98,8 +98,10 @@ RUN set -eux; \
 COPY --from=build /usr/local /usr/local
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
+	chmod 1777 /data && \
 	mkdir -p /run/valkey && \
 	chown valkey:valkey /run/valkey && \
+	chmod 1777 /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
 WORKDIR /data

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -96,8 +96,10 @@ RUN set -eux; \
 COPY --from=build /usr/local /usr/local
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
+	chmod 1777 /data && \
 	mkdir -p /run/valkey && \
 	chown valkey:valkey /run/valkey && \
+	chmod 1777 /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
 WORKDIR /data

--- a/8.0/alpine/Dockerfile
+++ b/8.0/alpine/Dockerfile
@@ -98,8 +98,10 @@ RUN set -eux; \
 COPY --from=build /usr/local /usr/local
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
+	chmod 1777 /data && \
 	mkdir -p /run/valkey && \
 	chown valkey:valkey /run/valkey && \
+	chmod 1777 /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
 WORKDIR /data

--- a/8.0/debian/Dockerfile
+++ b/8.0/debian/Dockerfile
@@ -96,8 +96,10 @@ RUN set -eux; \
 COPY --from=build /usr/local /usr/local
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
+	chmod 1777 /data && \
 	mkdir -p /run/valkey && \
 	chown valkey:valkey /run/valkey && \
+	chmod 1777 /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
 WORKDIR /data

--- a/8.1/alpine/Dockerfile
+++ b/8.1/alpine/Dockerfile
@@ -99,8 +99,10 @@ RUN set -eux; \
 COPY --from=build /usr/local /usr/local
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
+	chmod 1777 /data && \
 	mkdir -p /run/valkey && \
 	chown valkey:valkey /run/valkey && \
+	chmod 1777 /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
 WORKDIR /data

--- a/8.1/debian/Dockerfile
+++ b/8.1/debian/Dockerfile
@@ -100,8 +100,10 @@ RUN set -eux; \
 COPY --from=build /usr/local /usr/local
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
+	chmod 1777 /data && \
 	mkdir -p /run/valkey && \
 	chown valkey:valkey /run/valkey && \
+	chmod 1777 /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
 WORKDIR /data

--- a/9.0/alpine/Dockerfile
+++ b/9.0/alpine/Dockerfile
@@ -99,8 +99,10 @@ RUN set -eux; \
 COPY --from=build /usr/local /usr/local
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
+	chmod 1777 /data && \
 	mkdir -p /run/valkey && \
 	chown valkey:valkey /run/valkey && \
+	chmod 1777 /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
 WORKDIR /data

--- a/9.0/debian/Dockerfile
+++ b/9.0/debian/Dockerfile
@@ -100,8 +100,10 @@ RUN set -eux; \
 COPY --from=build /usr/local /usr/local
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
+	chmod 1777 /data && \
 	mkdir -p /run/valkey && \
 	chown valkey:valkey /run/valkey && \
+	chmod 1777 /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
 WORKDIR /data

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -176,8 +176,10 @@ RUN set -eux; \
 COPY --from=build /usr/local /usr/local
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
+	chmod 1777 /data && \
 	mkdir -p /run/valkey && \
 	chown valkey:valkey /run/valkey && \
+	chmod 1777 /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
 WORKDIR /data

--- a/unstable/alpine/Dockerfile
+++ b/unstable/alpine/Dockerfile
@@ -99,8 +99,10 @@ RUN set -eux; \
 COPY --from=build /usr/local /usr/local
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
+	chmod 1777 /data && \
 	mkdir -p /run/valkey && \
 	chown valkey:valkey /run/valkey && \
+	chmod 1777 /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
 WORKDIR /data

--- a/unstable/debian/Dockerfile
+++ b/unstable/debian/Dockerfile
@@ -100,8 +100,10 @@ RUN set -eux; \
 COPY --from=build /usr/local /usr/local
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
+	chmod 1777 /data && \
 	mkdir -p /run/valkey && \
 	chown valkey:valkey /run/valkey && \
+	chmod 1777 /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
 WORKDIR /data


### PR DESCRIPTION
When running the container with `--user <uid>:<gid>` where `uid != 0` and` uid != 999` (valkey), the `/data and /run/valkey` directories are owned by valkey (uid 999) causing permission denied errors.

Add `chmod 1777` (sticky-bit world-writable) to `/data` and `/run/valkey` so any `--user` can write to them. The sticky bit prevents users from deleting each other's files.

Existing behavior is unchanged:
- Default (no --user): starts as root, chowns to valkey, drops privs
- --user valkey: already owns /data, works as before

Add test that runs the container with `--user 1000:1000` and verifies `PING` and `SET/GET` work.

Fixes #77