### PR TITLE
Add a Dependabot config to update GitHub actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "semiannually"
+    cooldown:
+      default-days: 20
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
As requested in a [comment thread in #133](https://github.com/valkey-io/valkey-container/pull/133#discussion_r2927827920), this PR introduces a Dependabot config to regularly maintain GitHub action versions.

Dependabot will update action versions with these settings

* [Semiannual PRs](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#interval) (once every six months, on the first day of January and July)
* Grouped updates (one PR for all actions, rather than individually)
* 20-day cooldown (reduces supply chain attacks that target fast update turnarounds; only action versions published 20 or more days before Dependabot runs will be eligible update targets)
