### PR TITLE
Added libbacktrace support for alpine

### DIFF
--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -23,7 +23,21 @@ RUN set -eux; \
 		make \
 		musl-dev \
 		openssl-dev \
+		git \
+		autoconf \
+		automake \
+		libtool \
 	; \
+# build libbacktrace from source (not available as Alpine package)
+# pinned to commit 96664e69b1ecdb76e824be1d9e8f475b76dd08cf (2026-05-03)
+	git clone https://github.com/ianlancetaylor/libbacktrace.git /tmp/libbacktrace; \
+	cd /tmp/libbacktrace; \
+	git reset --hard 96664e69b1ecdb76e824be1d9e8f475b76dd08cf; \
+	./configure --prefix=/usr; \
+	make -j "$(nproc)"; \
+	make install; \
+	cd /; \
+	rm -rf /tmp/libbacktrace; \
 	\
 			echo "$VALKEY_DOWNLOAD_SHA *valkey.tar.gz" | sha256sum -c -; \
 		\
@@ -55,7 +69,7 @@ RUN set -eux; \
 	grep -F "cd jemalloc && ./configure $extraJemallocConfigureFlags " /usr/src/valkey/deps/Makefile; \
 	\
 	export BUILD_TLS=yes; \
-	\
+	export USE_LIBBACKTRACE=yes; \
 	make -C /usr/src/valkey -j "$(nproc)" all; \
 	make -C /usr/src/valkey install; \
 	\
@@ -96,6 +110,8 @@ RUN set -eux; \
 
 # Install valkey built earlier
 COPY --from=build /usr/local /usr/local
+# copy libbacktrace for backtrace support on musl
+COPY --from=build /usr/lib/libbacktrace.so* /usr/lib/
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
 	chmod 1777 /data && \

--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -110,8 +110,6 @@ RUN set -eux; \
 
 # Install valkey built earlier
 COPY --from=build /usr/local /usr/local
-# copy libbacktrace for backtrace support on musl
-COPY --from=build /usr/lib/libbacktrace.so* /usr/lib/
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
 	chmod 1777 /data && \

--- a/8.0/alpine/Dockerfile
+++ b/8.0/alpine/Dockerfile
@@ -23,7 +23,21 @@ RUN set -eux; \
 		make \
 		musl-dev \
 		openssl-dev \
+		git \
+		autoconf \
+		automake \
+		libtool \
 	; \
+# build libbacktrace from source (not available as Alpine package)
+# pinned to commit 96664e69b1ecdb76e824be1d9e8f475b76dd08cf (2026-05-03)
+	git clone https://github.com/ianlancetaylor/libbacktrace.git /tmp/libbacktrace; \
+	cd /tmp/libbacktrace; \
+	git reset --hard 96664e69b1ecdb76e824be1d9e8f475b76dd08cf; \
+	./configure --prefix=/usr; \
+	make -j "$(nproc)"; \
+	make install; \
+	cd /; \
+	rm -rf /tmp/libbacktrace; \
 	\
 			echo "$VALKEY_DOWNLOAD_SHA *valkey.tar.gz" | sha256sum -c -; \
 		\
@@ -55,7 +69,7 @@ RUN set -eux; \
 	grep -F "cd jemalloc && ./configure $extraJemallocConfigureFlags " /usr/src/valkey/deps/Makefile; \
 	\
 	export BUILD_TLS=yes; \
-	\
+	export USE_LIBBACKTRACE=yes; \
 	make -C /usr/src/valkey -j "$(nproc)" all; \
 	make -C /usr/src/valkey install; \
 	\
@@ -96,6 +110,8 @@ RUN set -eux; \
 
 # Install valkey built earlier
 COPY --from=build /usr/local /usr/local
+# copy libbacktrace for backtrace support on musl
+COPY --from=build /usr/lib/libbacktrace.so* /usr/lib/
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
 	chmod 1777 /data && \

--- a/8.0/alpine/Dockerfile
+++ b/8.0/alpine/Dockerfile
@@ -110,8 +110,6 @@ RUN set -eux; \
 
 # Install valkey built earlier
 COPY --from=build /usr/local /usr/local
-# copy libbacktrace for backtrace support on musl
-COPY --from=build /usr/lib/libbacktrace.so* /usr/lib/
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
 	chmod 1777 /data && \

--- a/8.1/alpine/Dockerfile
+++ b/8.1/alpine/Dockerfile
@@ -23,7 +23,21 @@ RUN set -eux; \
 		make \
 		musl-dev \
 		openssl-dev \
+		git \
+		autoconf \
+		automake \
+		libtool \
 	; \
+# build libbacktrace from source (not available as Alpine package)
+# pinned to commit 96664e69b1ecdb76e824be1d9e8f475b76dd08cf (2026-05-03)
+	git clone https://github.com/ianlancetaylor/libbacktrace.git /tmp/libbacktrace; \
+	cd /tmp/libbacktrace; \
+	git reset --hard 96664e69b1ecdb76e824be1d9e8f475b76dd08cf; \
+	./configure --prefix=/usr; \
+	make -j "$(nproc)"; \
+	make install; \
+	cd /; \
+	rm -rf /tmp/libbacktrace; \
 	\
 			echo "$VALKEY_DOWNLOAD_SHA *valkey.tar.gz" | sha256sum -c -; \
 		\
@@ -56,7 +70,7 @@ RUN set -eux; \
 	\
 	echo "Version 8.1.6 is 8.1 or higher - enabling USE_FAST_FLOAT"; \
 			export BUILD_TLS=yes USE_FAST_FLOAT=yes; \
-	\
+	export USE_LIBBACKTRACE=yes; \
 	make -C /usr/src/valkey -j "$(nproc)" all; \
 	make -C /usr/src/valkey install; \
 	\
@@ -97,6 +111,8 @@ RUN set -eux; \
 
 # Install valkey built earlier
 COPY --from=build /usr/local /usr/local
+# copy libbacktrace for backtrace support on musl
+COPY --from=build /usr/lib/libbacktrace.so* /usr/lib/
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
 	chmod 1777 /data && \

--- a/8.1/alpine/Dockerfile
+++ b/8.1/alpine/Dockerfile
@@ -111,8 +111,6 @@ RUN set -eux; \
 
 # Install valkey built earlier
 COPY --from=build /usr/local /usr/local
-# copy libbacktrace for backtrace support on musl
-COPY --from=build /usr/lib/libbacktrace.so* /usr/lib/
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
 	chmod 1777 /data && \

--- a/9.0/alpine/Dockerfile
+++ b/9.0/alpine/Dockerfile
@@ -23,7 +23,21 @@ RUN set -eux; \
 		make \
 		musl-dev \
 		openssl-dev \
+		git \
+		autoconf \
+		automake \
+		libtool \
 	; \
+# build libbacktrace from source (not available as Alpine package)
+# pinned to commit 96664e69b1ecdb76e824be1d9e8f475b76dd08cf (2026-05-03)
+	git clone https://github.com/ianlancetaylor/libbacktrace.git /tmp/libbacktrace; \
+	cd /tmp/libbacktrace; \
+	git reset --hard 96664e69b1ecdb76e824be1d9e8f475b76dd08cf; \
+	./configure --prefix=/usr; \
+	make -j "$(nproc)"; \
+	make install; \
+	cd /; \
+	rm -rf /tmp/libbacktrace; \
 	\
 			echo "$VALKEY_DOWNLOAD_SHA *valkey.tar.gz" | sha256sum -c -; \
 		\
@@ -56,7 +70,7 @@ RUN set -eux; \
 	\
 	echo "Version 9.0.3 is 8.1 or higher - enabling USE_FAST_FLOAT"; \
 			export BUILD_TLS=yes USE_FAST_FLOAT=yes; \
-	\
+	export USE_LIBBACKTRACE=yes; \
 	make -C /usr/src/valkey -j "$(nproc)" all; \
 	make -C /usr/src/valkey install; \
 	\
@@ -97,6 +111,8 @@ RUN set -eux; \
 
 # Install valkey built earlier
 COPY --from=build /usr/local /usr/local
+# copy libbacktrace for backtrace support on musl
+COPY --from=build /usr/lib/libbacktrace.so* /usr/lib/
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
 	chmod 1777 /data && \

--- a/9.0/alpine/Dockerfile
+++ b/9.0/alpine/Dockerfile
@@ -111,8 +111,6 @@ RUN set -eux; \
 
 # Install valkey built earlier
 COPY --from=build /usr/local /usr/local
-# copy libbacktrace for backtrace support on musl
-COPY --from=build /usr/lib/libbacktrace.so* /usr/lib/
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
 	chmod 1777 /data && \

--- a/9.1/alpine/Dockerfile
+++ b/9.1/alpine/Dockerfile
@@ -23,7 +23,21 @@ RUN set -eux; \
 		make \
 		musl-dev \
 		openssl-dev \
+		git \
+		autoconf \
+		automake \
+		libtool \
 	; \
+# build libbacktrace from source (not available as Alpine package)
+# pinned to commit 96664e69b1ecdb76e824be1d9e8f475b76dd08cf (2026-05-03)
+	git clone https://github.com/ianlancetaylor/libbacktrace.git /tmp/libbacktrace; \
+	cd /tmp/libbacktrace; \
+	git reset --hard 96664e69b1ecdb76e824be1d9e8f475b76dd08cf; \
+	./configure --prefix=/usr; \
+	make -j "$(nproc)"; \
+	make install; \
+	cd /; \
+	rm -rf /tmp/libbacktrace; \
 	\
 			echo "$VALKEY_DOWNLOAD_SHA *valkey.tar.gz" | sha256sum -c -; \
 		\
@@ -56,7 +70,7 @@ RUN set -eux; \
 	\
 	echo "Version 9.1.0-rc1 is 8.1 or higher - enabling USE_FAST_FLOAT"; \
 			export BUILD_TLS=yes USE_FAST_FLOAT=yes; \
-	\
+	export USE_LIBBACKTRACE=yes; \
 	make -C /usr/src/valkey -j "$(nproc)" all; \
 	make -C /usr/src/valkey install; \
 	\
@@ -97,10 +111,14 @@ RUN set -eux; \
 
 # Install valkey built earlier
 COPY --from=build /usr/local /usr/local
+# copy libbacktrace for backtrace support on musl
+COPY --from=build /usr/lib/libbacktrace.so* /usr/lib/
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
+	chmod 1777 /data && \
 	mkdir -p /run/valkey && \
 	chown valkey:valkey /run/valkey && \
+	chmod 1777 /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
 WORKDIR /data

--- a/9.1/alpine/Dockerfile
+++ b/9.1/alpine/Dockerfile
@@ -111,8 +111,6 @@ RUN set -eux; \
 
 # Install valkey built earlier
 COPY --from=build /usr/local /usr/local
-# copy libbacktrace for backtrace support on musl
-COPY --from=build /usr/lib/libbacktrace.so* /usr/lib/
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
 	chmod 1777 /data && \

--- a/9.1/debian/Dockerfile
+++ b/9.1/debian/Dockerfile
@@ -100,8 +100,10 @@ RUN set -eux; \
 COPY --from=build /usr/local /usr/local
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
+	chmod 1777 /data && \
 	mkdir -p /run/valkey && \
 	chown valkey:valkey /run/valkey && \
+	chmod 1777 /run/valkey && \
 	valkey-cli --version && \
 	valkey-server --version
 WORKDIR /data

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -23,7 +23,19 @@ RUN set -eux; \
 		make \
 		musl-dev \
 		openssl-dev \
+		git \
+		autoconf \
+		automake \
+		libtool \
 	; \
+# build libbacktrace from source (not available as Alpine package)
+	git clone --depth 1 https://github.com/ianlancetaylor/libbacktrace.git /tmp/libbacktrace; \
+	cd /tmp/libbacktrace; \
+	./configure --prefix=/usr; \
+	make -j "$(nproc)"; \
+	make install; \
+	cd /; \
+	rm -rf /tmp/libbacktrace; \
 {{ ) else ( -}}
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
@@ -92,7 +104,7 @@ RUN set -eux; \
 	export BUILD_TLS=yes; \
 {{ ) end -}}
 {{ if env.variant == "alpine" then ( -}}
-	\
+	export USE_LIBBACKTRACE=yes; \
 {{ ) else ( -}}
 	export USE_SYSTEMD=yes; \
 {{ ) end -}}
@@ -174,6 +186,10 @@ RUN set -eux; \
 
 # Install valkey built earlier
 COPY --from=build /usr/local /usr/local
+{{ if env.variant == "alpine" then ( -}}
+# copy libbacktrace for backtrace support on musl
+COPY --from=build /usr/lib/libbacktrace.so* /usr/lib/
+{{ ) else "" end -}}
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
 	chmod 1777 /data && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -29,8 +29,10 @@ RUN set -eux; \
 		libtool \
 	; \
 # build libbacktrace from source (not available as Alpine package)
+# pinned to commit 96664e69b1ecdb76e824be1d9e8f475b76dd08cf (2026-05-03)
 	git clone --depth 1 https://github.com/ianlancetaylor/libbacktrace.git /tmp/libbacktrace; \
 	cd /tmp/libbacktrace; \
+	git checkout 96664e69b1ecdb76e824be1d9e8f475b76dd08cf; \
 	./configure --prefix=/usr; \
 	make -j "$(nproc)"; \
 	make install; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -30,9 +30,9 @@ RUN set -eux; \
 	; \
 # build libbacktrace from source (not available as Alpine package)
 # pinned to commit 96664e69b1ecdb76e824be1d9e8f475b76dd08cf (2026-05-03)
-	git clone --depth 1 https://github.com/ianlancetaylor/libbacktrace.git /tmp/libbacktrace; \
+	git clone https://github.com/ianlancetaylor/libbacktrace.git /tmp/libbacktrace; \
 	cd /tmp/libbacktrace; \
-	git checkout 96664e69b1ecdb76e824be1d9e8f475b76dd08cf; \
+	git reset --hard 96664e69b1ecdb76e824be1d9e8f475b76dd08cf; \
 	./configure --prefix=/usr; \
 	make -j "$(nproc)"; \
 	make install; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -188,10 +188,6 @@ RUN set -eux; \
 
 # Install valkey built earlier
 COPY --from=build /usr/local /usr/local
-{{ if env.variant == "alpine" then ( -}}
-# copy libbacktrace for backtrace support on musl
-COPY --from=build /usr/lib/libbacktrace.so* /usr/lib/
-{{ ) else "" end -}}
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
 	chmod 1777 /data && \

--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ You should build and publish a new Docker Image after a new major, minor or patc
 5. Verify all the tests pass on your fork and that your private Docker Hub repository has been updated.
 6. Publish a PR with these changes. For example: [#8](https://github.com/valkey-io/valkey-container/pull/8)
 7. Once the PR is merged, Sit back, relax and enjoy looking at your creation getting published to the official Docker Hub page.
+Dummy change

--- a/README.md
+++ b/README.md
@@ -20,4 +20,3 @@ You should build and publish a new Docker Image after a new major, minor or patc
 5. Verify all the tests pass on your fork and that your private Docker Hub repository has been updated.
 6. Publish a PR with these changes. For example: [#8](https://github.com/valkey-io/valkey-container/pull/8)
 7. Once the PR is merged, Sit back, relax and enjoy looking at your creation getting published to the official Docker Hub page.
-Dummy change

--- a/unstable/alpine/Dockerfile
+++ b/unstable/alpine/Dockerfile
@@ -23,7 +23,21 @@ RUN set -eux; \
 		make \
 		musl-dev \
 		openssl-dev \
+		git \
+		autoconf \
+		automake \
+		libtool \
 	; \
+# build libbacktrace from source (not available as Alpine package)
+# pinned to commit 96664e69b1ecdb76e824be1d9e8f475b76dd08cf (2026-05-03)
+	git clone https://github.com/ianlancetaylor/libbacktrace.git /tmp/libbacktrace; \
+	cd /tmp/libbacktrace; \
+	git reset --hard 96664e69b1ecdb76e824be1d9e8f475b76dd08cf; \
+	./configure --prefix=/usr; \
+	make -j "$(nproc)"; \
+	make install; \
+	cd /; \
+	rm -rf /tmp/libbacktrace; \
 	\
 			echo "Unstable Valkey version, do not compare SHA256SUM" ;\
 		\
@@ -56,7 +70,7 @@ RUN set -eux; \
 	\
 	echo "Unstable version detected — enabling USE_FAST_FLOAT"; \
 			export BUILD_TLS=yes USE_FAST_FLOAT=yes; \
-	\
+	export USE_LIBBACKTRACE=yes; \
 	make -C /usr/src/valkey -j "$(nproc)" all; \
 	make -C /usr/src/valkey install; \
 	\
@@ -97,6 +111,8 @@ RUN set -eux; \
 
 # Install valkey built earlier
 COPY --from=build /usr/local /usr/local
+# copy libbacktrace for backtrace support on musl
+COPY --from=build /usr/lib/libbacktrace.so* /usr/lib/
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
 	chmod 1777 /data && \

--- a/unstable/alpine/Dockerfile
+++ b/unstable/alpine/Dockerfile
@@ -111,8 +111,6 @@ RUN set -eux; \
 
 # Install valkey built earlier
 COPY --from=build /usr/local /usr/local
-# copy libbacktrace for backtrace support on musl
-COPY --from=build /usr/lib/libbacktrace.so* /usr/lib/
 RUN mkdir /data && \
 	chown valkey:valkey /data && \
 	chmod 1777 /data && \


### PR DESCRIPTION
libbacktrace is not available as an Alpine package, so this PR builds it from source during the Alpine Docker build and links it into the final image
- Build libbacktrace from source in the Alpine build stage
- Pass `USE_LIBBACKTRACE=yes` to the valkey make invocation on Alpine
- Copy `libbacktrace.so` into the runtime image
Related PR: https://github.com/valkey-io/valkey/pull/3581
