### PR TITLE
Fix SBOM to be valid SPDX 2.3 and add validation test

### DIFF
--- a/.test/config.sh
+++ b/.test/config.sh
@@ -8,5 +8,6 @@ imageTests+=(
 		valkey-basics-persistent
 		valkey-readonly-data
 		valkey-user-flag
+		valkey-sbom
 	'
 )

--- a/.test/tests/valkey-sbom/run.sh
+++ b/.test/tests/valkey-sbom/run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+image="$1"
+
+# Mirror of the official python image (avoids Docker Hub pull limits)
+pythonImage='public.ecr.aws/docker/library/python:3.12-slim'
+
+# Pre-pull with retries: parallel CI jobs pulling the same image from shared
+# runner IPs can hit anonymous registry rate limits (toomanyrequests).
+# NOTE: retry.sh is sourced and its --image flag would clobber our $image.
+. "$dir/../../retry.sh" --tries 10 --sleep 15 "docker pull -q '$pythonImage'"
+
+# Extract the SBOM shipped in the image
+sbom="$(docker run --rm --entrypoint cat "$image" /usr/local/valkey.spdx.json)"
+
+# Validate it with the reference SPDX validator (spdx-tools).
+# Runs in a throwaway container so the test host only needs docker.
+# pyspdxtools detects the document format from the file extension, hence the
+# .spdx.json filename. Version pinned for reproducible CI runs.
+if ! echo "$sbom" | docker run --rm -i "$pythonImage" sh -euc '
+	pip install --quiet --no-input "spdx-tools==0.8.3" >/dev/null 2>&1
+	cat > /tmp/sbom.spdx.json
+	pyspdxtools -i /tmp/sbom.spdx.json
+'; then
+	echo >&2 "ERROR: /usr/local/valkey.spdx.json is not a valid SPDX 2.3 document:"
+	echo >&2 "$sbom"
+	exit 1
+fi
+
+echo "PASS: SBOM is a valid SPDX 2.3 document"

--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -83,7 +83,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"7.2.14","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@7.2.14?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-7.2.14-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"7.2.14","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/7.2.14.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@7.2.14?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -69,7 +69,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"7.2.14","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@7.2.14?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-7.2.14-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"7.2.14","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/7.2.14.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@7.2.14?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/8.0/alpine/Dockerfile
+++ b/8.0/alpine/Dockerfile
@@ -83,7 +83,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"8.0.10","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.10?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.0.10-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.0.10","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.0.10.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.10?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/8.0/debian/Dockerfile
+++ b/8.0/debian/Dockerfile
@@ -69,7 +69,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"8.0.10","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.10?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.0.10-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.0.10","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.0.10.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.10?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/8.1/alpine/Dockerfile
+++ b/8.1/alpine/Dockerfile
@@ -84,7 +84,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"8.1.9","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.1.9?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.1.9-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.1.9","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.1.9.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.1.9?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/8.1/debian/Dockerfile
+++ b/8.1/debian/Dockerfile
@@ -73,7 +73,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"8.1.9","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.1.9?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.1.9-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.1.9","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.1.9.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.1.9?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/9.0/alpine/Dockerfile
+++ b/9.0/alpine/Dockerfile
@@ -84,7 +84,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"9.0.5","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.0.5?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.0.5-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.0.5","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.0.5.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.0.5?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/9.0/debian/Dockerfile
+++ b/9.0/debian/Dockerfile
@@ -73,7 +73,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"9.0.5","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.0.5?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.0.5-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.0.5","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.0.5.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.0.5?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/9.1/alpine/Dockerfile
+++ b/9.1/alpine/Dockerfile
@@ -84,7 +84,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"9.1.1","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.1.1?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.1.1-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.1.1","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.1.1.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.1.1?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/9.1/debian/Dockerfile
+++ b/9.1/debian/Dockerfile
@@ -73,7 +73,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"9.1.1","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.1.1?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.1.1-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.1.1","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.1.1.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.1.1?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,5 @@
 {{ include ".template-helper-functions" -}}
+{{ include "valkey-sbom" -}}
 {{ if env.variant == "alpine" then ( -}}
 FROM alpine:{{ .alpine.version }} AS base
 {{ ) else ( -}}
@@ -123,10 +124,12 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
 	echo {{
 		{
 			name: "valkey-server",
 			version: .version,
+			downloadLocation: .url,
 			params: (
 				if env.variant == "alpine" then
 					{
@@ -143,8 +146,9 @@ RUN set -eux; \
 			licenses: [
 				"BSD-3-Clause"
 			]
-		} | sbom | tostring | @sh
-	}} > /usr/local/valkey.spdx.json
+		} | valkey_sbom | tostring | @sh
+	}} \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/unstable/alpine/Dockerfile
+++ b/unstable/alpine/Dockerfile
@@ -84,7 +84,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"unstable","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@unstable?os_name=alpine&os_version=3.23"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-unstable-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"unstable","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/unstable.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@unstable?os_name=alpine&os_version=3.23"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/unstable/debian/Dockerfile
+++ b/unstable/debian/Dockerfile
@@ -73,7 +73,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"unstable","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@unstable?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-unstable-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"unstable","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/unstable.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@unstable?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/valkey-sbom.jq
+++ b/valkey-sbom.jq
@@ -1,0 +1,58 @@
+# Valkey-specific replacement for bashbrew's stock "sbom" template helper.
+#
+# The stock helper (auto-downloaded, gitignored .template-helper-functions.jq)
+# omits fields that SPDX 2.3 marks mandatory, so strict scanners reject the
+# resulting document (https://github.com/valkey-io/valkey-container/issues/114).
+# This tracked module produces a minimal but spec-compliant SPDX 2.3 document.
+#
+# input:
+# {
+#     name: "packageName",
+#     version: "packageVersion",
+#     downloadLocation: "https://.../source.tar.gz",
+#     params: {
+#         "foo": "bar"
+#     },
+#     licenses: ["packageLicense" ... ]
+# }
+# output: object
+#
+# The "@SPDX_CREATED@" token is substituted with the real build-time timestamp
+# in Dockerfile.template.
+def valkey_sbom:
+    {
+		spdxVersion: "SPDX-2.3",
+		dataLicense: "CC0-1.0",
+		SPDXID: "SPDXRef-DOCUMENT",
+		name: (.name + "-sbom"),
+		documentNamespace: ("https://valkey.io/spdxdocs/" + .name + "-sbom-" + .version + "-@SPDX_CREATED@"),
+		creationInfo: {
+			created: "@SPDX_CREATED@",
+			creators: [
+				"Organization: The Valkey Project",
+				"Tool: valkey-container"
+			]
+		},
+		packages: [
+			{
+				name: .name,
+				versionInfo: .version,
+				SPDXID: ("SPDXRef-Package--" + .name),
+				downloadLocation: (.downloadLocation // "NOASSERTION"),
+				filesAnalyzed: false,
+				externalRefs: [
+					{
+						referenceCategory: "PACKAGE-MANAGER",
+						referenceType: "purl",
+						referenceLocator: ("pkg:generic/" + .name + "@" + .version + "?" + (.params | [to_entries[] | .key + "=" + .value] | join("\u0026")))
+					}
+				],
+				licenseDeclared: (if .licenses | length > 0 then
+					(.licenses | join(" AND "))
+				else
+					"NOASSERTION"
+				end)
+			}
+		]
+	}
+;


### PR DESCRIPTION
Fixes #114
The SBOM at `/usr/local/valkey.spdx.json` was missing fields that SPDX 2.3 marks mandatory, so strict scanners like Nexus IQ reject it with "SPDX content cannot be parsed".

Changes:
- Add missing mandatory fields to the SBOM according to the spec.
- Add a `valkey-sbom` test that validates the shipped SBOM with the reference spdx-tools validator in a throwaway container.