### PR TITLE
Fix SBOM to be valid SPDX 2.3 and add validation test

### DIFF
--- a/.test/config.sh
+++ b/.test/config.sh
@@ -8,5 +8,6 @@ imageTests+=(
 		valkey-basics-persistent
 		valkey-readonly-data
 		valkey-user-flag
+		valkey-sbom
 	'
 )

--- a/.test/tests/valkey-sbom/run.sh
+++ b/.test/tests/valkey-sbom/run.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+image="$1"
+
+# Mirror of the official python image (avoids Docker Hub pull limits)
+pythonImage='public.ecr.aws/docker/library/python:3.12-slim'
+
+# Pre-pull with retries: parallel CI jobs pulling the same image from shared
+# runner IPs can hit anonymous registry rate limits (toomanyrequests).
+# NOTE: retry.sh is sourced and its --image flag would clobber our $image.
+. "$dir/../../retry.sh" --tries 10 --sleep 15 "docker pull -q '$pythonImage'"
+
+# Extract the SBOM shipped in the image
+sbom="$(docker run --rm --entrypoint cat "$image" /usr/local/valkey.spdx.json)"
+
+# Validate it with the reference SPDX validator (spdx-tools).
+# Runs in a throwaway container so the test host only needs docker.
+# pyspdxtools detects the document format from the file extension, hence the
+# .spdx.json filename. Version pinned for reproducible CI runs.
+if ! echo "$sbom" | docker run --rm -i "$pythonImage" sh -euc '
+	pip install --quiet --no-input "spdx-tools==0.8.3" >/dev/null 2>&1
+	cat > /tmp/sbom.spdx.json
+	pyspdxtools -i /tmp/sbom.spdx.json
+'; then
+	echo >&2 "ERROR: /usr/local/valkey.spdx.json is not a valid SPDX 2.3 document:"
+	echo >&2 "$sbom"
+	exit 1
+fi
+
+echo "PASS: SBOM is a valid SPDX 2.3 document"

--- a/.test/tests/valkey-sbom/run.sh
+++ b/.test/tests/valkey-sbom/run.sh
@@ -13,15 +13,29 @@ pythonImage='public.ecr.aws/docker/library/python:3.12-slim'
 # NOTE: retry.sh is sourced and its --image flag would clobber our $image.
 . "$dir/../../retry.sh" --tries 10 --sleep 15 "docker pull -q '$pythonImage'"
 
+# Build the reference SPDX validator (spdx-tools) into its own image, so the
+# test host only needs docker. Version pinned for reproducible CI runs.
+# This is a separate step from validation below so that an install failure
+# (PyPI outage, yanked release) is not misreported as an invalid SBOM.
+# The tag is fixed rather than derived from $image because the validator does
+# not depend on the image under test.
+validatorImage='librarytest/valkey-sbom-validator:spdx-tools-0.8.3'
+if ! "$dir/../docker-build.sh" "$dir" "$validatorImage" <<-EOD
+	FROM $pythonImage
+	RUN pip install --no-input "spdx-tools==0.8.3"
+EOD
+then
+	echo >&2 "ERROR: could not build the spdx-tools validator image; this is an"
+	echo >&2 "infrastructure failure (registry or PyPI), not an SBOM problem."
+	exit 1
+fi
+
 # Extract the SBOM shipped in the image
 sbom="$(docker run --rm --entrypoint cat "$image" /usr/local/valkey.spdx.json)"
 
-# Validate it with the reference SPDX validator (spdx-tools).
-# Runs in a throwaway container so the test host only needs docker.
-# pyspdxtools detects the document format from the file extension, hence the
-# .spdx.json filename. Version pinned for reproducible CI runs.
-if ! echo "$sbom" | docker run --rm -i "$pythonImage" sh -euc '
-	pip install --quiet --no-input "spdx-tools==0.8.3" >/dev/null 2>&1
+# pyspdxtools infers the document format from the file extension, hence the
+# .spdx.json filename.
+if ! echo "$sbom" | docker run --rm -i --entrypoint sh "$validatorImage" -euc '
 	cat > /tmp/sbom.spdx.json
 	pyspdxtools -i /tmp/sbom.spdx.json
 '; then

--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -83,7 +83,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"7.2.14","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@7.2.14?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-7.2.14-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"7.2.14","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/7.2.14.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@7.2.14?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -84,7 +84,7 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-7.2.14-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"7.2.14","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/7.2.14.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@7.2.14?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-7.2.14-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"7.2.14","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/7.2.14.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@7.2.14?os_name=alpine&os_version=3.24"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:7.2.14:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
 		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base

--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -84,8 +84,9 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-7.2.14-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"7.2.14","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/7.2.14.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@7.2.14?os_name=alpine&os_version=3.24"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:7.2.14:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
-		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
+	SPDX_UUID="$(cat /proc/sys/kernel/random/uuid)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-7.2.14-alpine-3.24-@SPDX_UUID@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"7.2.14","SPDXID":"SPDXRef-Package--valkey-server","supplier":"Organization: The Valkey Project","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/7.2.14.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@7.2.14?os_name=alpine&os_version=3.24"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:7.2.14:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}],"relationships":[{"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"SPDXRef-Package--valkey-server"}]}' \
+		| sed -e "s|@SPDX_CREATED@|$SPDX_CREATED|g" -e "s|@SPDX_UUID@|$SPDX_UUID|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -69,7 +69,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"7.2.14","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@7.2.14?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-7.2.14-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"7.2.14","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/7.2.14.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@7.2.14?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -70,8 +70,9 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-7.2.14-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"7.2.14","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/7.2.14.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@7.2.14?os_name=debian&os_version=trixie"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:7.2.14:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
-		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
+	SPDX_UUID="$(cat /proc/sys/kernel/random/uuid)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-7.2.14-debian-trixie-@SPDX_UUID@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"7.2.14","SPDXID":"SPDXRef-Package--valkey-server","supplier":"Organization: The Valkey Project","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/7.2.14.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@7.2.14?os_name=debian&os_version=trixie"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:7.2.14:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}],"relationships":[{"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"SPDXRef-Package--valkey-server"}]}' \
+		| sed -e "s|@SPDX_CREATED@|$SPDX_CREATED|g" -e "s|@SPDX_UUID@|$SPDX_UUID|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -70,7 +70,7 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-7.2.14-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"7.2.14","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/7.2.14.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@7.2.14?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-7.2.14-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"7.2.14","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/7.2.14.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@7.2.14?os_name=debian&os_version=trixie"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:7.2.14:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
 		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base

--- a/8.0/alpine/Dockerfile
+++ b/8.0/alpine/Dockerfile
@@ -84,7 +84,7 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.0.10-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.0.10","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.0.10.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.10?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.0.10-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.0.10","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.0.10.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.10?os_name=alpine&os_version=3.24"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:8.0.10:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
 		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base

--- a/8.0/alpine/Dockerfile
+++ b/8.0/alpine/Dockerfile
@@ -84,8 +84,9 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.0.10-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.0.10","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.0.10.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.10?os_name=alpine&os_version=3.24"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:8.0.10:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
-		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
+	SPDX_UUID="$(cat /proc/sys/kernel/random/uuid)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.0.10-alpine-3.24-@SPDX_UUID@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.0.10","SPDXID":"SPDXRef-Package--valkey-server","supplier":"Organization: The Valkey Project","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.0.10.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.10?os_name=alpine&os_version=3.24"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:8.0.10:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}],"relationships":[{"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"SPDXRef-Package--valkey-server"}]}' \
+		| sed -e "s|@SPDX_CREATED@|$SPDX_CREATED|g" -e "s|@SPDX_UUID@|$SPDX_UUID|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/8.0/alpine/Dockerfile
+++ b/8.0/alpine/Dockerfile
@@ -83,7 +83,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"8.0.10","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.10?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.0.10-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.0.10","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.0.10.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.10?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/8.0/debian/Dockerfile
+++ b/8.0/debian/Dockerfile
@@ -70,8 +70,9 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.0.10-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.0.10","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.0.10.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.10?os_name=debian&os_version=trixie"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:8.0.10:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
-		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
+	SPDX_UUID="$(cat /proc/sys/kernel/random/uuid)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.0.10-debian-trixie-@SPDX_UUID@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.0.10","SPDXID":"SPDXRef-Package--valkey-server","supplier":"Organization: The Valkey Project","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.0.10.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.10?os_name=debian&os_version=trixie"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:8.0.10:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}],"relationships":[{"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"SPDXRef-Package--valkey-server"}]}' \
+		| sed -e "s|@SPDX_CREATED@|$SPDX_CREATED|g" -e "s|@SPDX_UUID@|$SPDX_UUID|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/8.0/debian/Dockerfile
+++ b/8.0/debian/Dockerfile
@@ -70,7 +70,7 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.0.10-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.0.10","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.0.10.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.10?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.0.10-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.0.10","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.0.10.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.10?os_name=debian&os_version=trixie"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:8.0.10:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
 		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base

--- a/8.0/debian/Dockerfile
+++ b/8.0/debian/Dockerfile
@@ -69,7 +69,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"8.0.10","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.10?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.0.10-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.0.10","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.0.10.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.0.10?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/8.1/alpine/Dockerfile
+++ b/8.1/alpine/Dockerfile
@@ -85,7 +85,7 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.1.9-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.1.9","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.1.9.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.1.9?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.1.9-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.1.9","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.1.9.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.1.9?os_name=alpine&os_version=3.24"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:8.1.9:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
 		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base

--- a/8.1/alpine/Dockerfile
+++ b/8.1/alpine/Dockerfile
@@ -84,7 +84,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"8.1.9","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.1.9?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.1.9-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.1.9","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.1.9.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.1.9?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/8.1/alpine/Dockerfile
+++ b/8.1/alpine/Dockerfile
@@ -85,8 +85,9 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.1.9-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.1.9","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.1.9.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.1.9?os_name=alpine&os_version=3.24"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:8.1.9:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
-		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
+	SPDX_UUID="$(cat /proc/sys/kernel/random/uuid)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.1.9-alpine-3.24-@SPDX_UUID@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.1.9","SPDXID":"SPDXRef-Package--valkey-server","supplier":"Organization: The Valkey Project","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.1.9.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.1.9?os_name=alpine&os_version=3.24"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:8.1.9:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}],"relationships":[{"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"SPDXRef-Package--valkey-server"}]}' \
+		| sed -e "s|@SPDX_CREATED@|$SPDX_CREATED|g" -e "s|@SPDX_UUID@|$SPDX_UUID|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/8.1/debian/Dockerfile
+++ b/8.1/debian/Dockerfile
@@ -73,7 +73,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"8.1.9","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.1.9?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.1.9-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.1.9","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.1.9.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.1.9?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/8.1/debian/Dockerfile
+++ b/8.1/debian/Dockerfile
@@ -74,7 +74,7 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.1.9-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.1.9","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.1.9.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.1.9?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.1.9-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.1.9","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.1.9.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.1.9?os_name=debian&os_version=trixie"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:8.1.9:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
 		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base

--- a/8.1/debian/Dockerfile
+++ b/8.1/debian/Dockerfile
@@ -74,8 +74,9 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.1.9-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.1.9","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.1.9.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.1.9?os_name=debian&os_version=trixie"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:8.1.9:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
-		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
+	SPDX_UUID="$(cat /proc/sys/kernel/random/uuid)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-8.1.9-debian-trixie-@SPDX_UUID@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"8.1.9","SPDXID":"SPDXRef-Package--valkey-server","supplier":"Organization: The Valkey Project","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/8.1.9.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@8.1.9?os_name=debian&os_version=trixie"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:8.1.9:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}],"relationships":[{"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"SPDXRef-Package--valkey-server"}]}' \
+		| sed -e "s|@SPDX_CREATED@|$SPDX_CREATED|g" -e "s|@SPDX_UUID@|$SPDX_UUID|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/9.0/alpine/Dockerfile
+++ b/9.0/alpine/Dockerfile
@@ -85,7 +85,7 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.0.5-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.0.5","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.0.5.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.0.5?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.0.5-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.0.5","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.0.5.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.0.5?os_name=alpine&os_version=3.24"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:9.0.5:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
 		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base

--- a/9.0/alpine/Dockerfile
+++ b/9.0/alpine/Dockerfile
@@ -84,7 +84,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"9.0.5","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.0.5?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.0.5-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.0.5","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.0.5.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.0.5?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/9.0/alpine/Dockerfile
+++ b/9.0/alpine/Dockerfile
@@ -85,8 +85,9 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.0.5-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.0.5","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.0.5.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.0.5?os_name=alpine&os_version=3.24"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:9.0.5:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
-		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
+	SPDX_UUID="$(cat /proc/sys/kernel/random/uuid)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.0.5-alpine-3.24-@SPDX_UUID@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.0.5","SPDXID":"SPDXRef-Package--valkey-server","supplier":"Organization: The Valkey Project","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.0.5.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.0.5?os_name=alpine&os_version=3.24"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:9.0.5:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}],"relationships":[{"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"SPDXRef-Package--valkey-server"}]}' \
+		| sed -e "s|@SPDX_CREATED@|$SPDX_CREATED|g" -e "s|@SPDX_UUID@|$SPDX_UUID|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/9.0/debian/Dockerfile
+++ b/9.0/debian/Dockerfile
@@ -73,7 +73,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"9.0.5","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.0.5?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.0.5-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.0.5","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.0.5.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.0.5?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/9.0/debian/Dockerfile
+++ b/9.0/debian/Dockerfile
@@ -74,8 +74,9 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.0.5-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.0.5","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.0.5.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.0.5?os_name=debian&os_version=trixie"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:9.0.5:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
-		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
+	SPDX_UUID="$(cat /proc/sys/kernel/random/uuid)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.0.5-debian-trixie-@SPDX_UUID@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.0.5","SPDXID":"SPDXRef-Package--valkey-server","supplier":"Organization: The Valkey Project","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.0.5.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.0.5?os_name=debian&os_version=trixie"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:9.0.5:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}],"relationships":[{"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"SPDXRef-Package--valkey-server"}]}' \
+		| sed -e "s|@SPDX_CREATED@|$SPDX_CREATED|g" -e "s|@SPDX_UUID@|$SPDX_UUID|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/9.0/debian/Dockerfile
+++ b/9.0/debian/Dockerfile
@@ -74,7 +74,7 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.0.5-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.0.5","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.0.5.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.0.5?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.0.5-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.0.5","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.0.5.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.0.5?os_name=debian&os_version=trixie"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:9.0.5:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
 		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base

--- a/9.1/alpine/Dockerfile
+++ b/9.1/alpine/Dockerfile
@@ -84,7 +84,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"9.1.1","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.1.1?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.1.1-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.1.1","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.1.1.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.1.1?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/9.1/alpine/Dockerfile
+++ b/9.1/alpine/Dockerfile
@@ -85,7 +85,7 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.1.1-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.1.1","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.1.1.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.1.1?os_name=alpine&os_version=3.24"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.1.1-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.1.1","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.1.1.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.1.1?os_name=alpine&os_version=3.24"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:9.1.1:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
 		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base

--- a/9.1/alpine/Dockerfile
+++ b/9.1/alpine/Dockerfile
@@ -85,8 +85,9 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.1.1-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.1.1","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.1.1.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.1.1?os_name=alpine&os_version=3.24"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:9.1.1:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
-		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
+	SPDX_UUID="$(cat /proc/sys/kernel/random/uuid)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.1.1-alpine-3.24-@SPDX_UUID@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.1.1","SPDXID":"SPDXRef-Package--valkey-server","supplier":"Organization: The Valkey Project","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.1.1.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.1.1?os_name=alpine&os_version=3.24"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:9.1.1:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}],"relationships":[{"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"SPDXRef-Package--valkey-server"}]}' \
+		| sed -e "s|@SPDX_CREATED@|$SPDX_CREATED|g" -e "s|@SPDX_UUID@|$SPDX_UUID|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/9.1/debian/Dockerfile
+++ b/9.1/debian/Dockerfile
@@ -73,7 +73,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"9.1.1","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.1.1?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.1.1-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.1.1","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.1.1.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.1.1?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/9.1/debian/Dockerfile
+++ b/9.1/debian/Dockerfile
@@ -74,7 +74,7 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.1.1-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.1.1","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.1.1.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.1.1?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.1.1-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.1.1","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.1.1.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.1.1?os_name=debian&os_version=trixie"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:9.1.1:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
 		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base

--- a/9.1/debian/Dockerfile
+++ b/9.1/debian/Dockerfile
@@ -74,8 +74,9 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.1.1-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.1.1","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.1.1.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.1.1?os_name=debian&os_version=trixie"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:9.1.1:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
-		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
+	SPDX_UUID="$(cat /proc/sys/kernel/random/uuid)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-9.1.1-debian-trixie-@SPDX_UUID@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"9.1.1","SPDXID":"SPDXRef-Package--valkey-server","supplier":"Organization: The Valkey Project","downloadLocation":"https://github.com/valkey-io/valkey/archive/refs/tags/9.1.1.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@9.1.1?os_name=debian&os_version=trixie"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:9.1.1:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}],"relationships":[{"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"SPDXRef-Package--valkey-server"}]}' \
+		| sed -e "s|@SPDX_CREATED@|$SPDX_CREATED|g" -e "s|@SPDX_UUID@|$SPDX_UUID|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -125,6 +125,7 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	SPDX_UUID="$(cat /proc/sys/kernel/random/uuid)"; \
 	echo {{
 		{
 			name: "valkey-server",
@@ -148,7 +149,7 @@ RUN set -eux; \
 			]
 		} | valkey_sbom | tostring | @sh
 	}} \
-		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
+		| sed -e "s|@SPDX_CREATED@|$SPDX_CREATED|g" -e "s|@SPDX_UUID@|$SPDX_UUID|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,5 @@
 {{ include ".template-helper-functions" -}}
+{{ include "valkey-sbom" -}}
 {{ if env.variant == "alpine" then ( -}}
 FROM alpine:{{ .alpine.version }} AS base
 {{ ) else ( -}}
@@ -123,10 +124,12 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
 	echo {{
 		{
 			name: "valkey-server",
 			version: .version,
+			downloadLocation: .url,
 			params: (
 				if env.variant == "alpine" then
 					{
@@ -143,8 +146,9 @@ RUN set -eux; \
 			licenses: [
 				"BSD-3-Clause"
 			]
-		} | sbom | tostring | @sh
-	}} > /usr/local/valkey.spdx.json
+		} | valkey_sbom | tostring | @sh
+	}} \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/unstable/alpine/Dockerfile
+++ b/unstable/alpine/Dockerfile
@@ -84,7 +84,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"unstable","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@unstable?os_name=alpine&os_version=3.23"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-unstable-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"unstable","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/unstable.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@unstable?os_name=alpine&os_version=3.23"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/unstable/alpine/Dockerfile
+++ b/unstable/alpine/Dockerfile
@@ -85,7 +85,7 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-unstable-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"unstable","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/unstable.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@unstable?os_name=alpine&os_version=3.23"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-unstable-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"unstable","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/unstable.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@unstable?os_name=alpine&os_version=3.23"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:unstable:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
 		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base

--- a/unstable/alpine/Dockerfile
+++ b/unstable/alpine/Dockerfile
@@ -85,8 +85,9 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-unstable-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"unstable","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/unstable.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@unstable?os_name=alpine&os_version=3.23"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:unstable:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
-		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
+	SPDX_UUID="$(cat /proc/sys/kernel/random/uuid)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-unstable-alpine-3.23-@SPDX_UUID@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"unstable","SPDXID":"SPDXRef-Package--valkey-server","supplier":"Organization: The Valkey Project","downloadLocation":"https://github.com/valkey-io/valkey/archive/unstable.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@unstable?os_name=alpine&os_version=3.23"}],"licenseDeclared":"BSD-3-Clause"}],"relationships":[{"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"SPDXRef-Package--valkey-server"}]}' \
+		| sed -e "s|@SPDX_CREATED@|$SPDX_CREATED|g" -e "s|@SPDX_UUID@|$SPDX_UUID|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/unstable/debian/Dockerfile
+++ b/unstable/debian/Dockerfile
@@ -74,8 +74,9 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-unstable-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"unstable","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/unstable.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@unstable?os_name=debian&os_version=trixie"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:unstable:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
-		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
+	SPDX_UUID="$(cat /proc/sys/kernel/random/uuid)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-unstable-debian-trixie-@SPDX_UUID@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"unstable","SPDXID":"SPDXRef-Package--valkey-server","supplier":"Organization: The Valkey Project","downloadLocation":"https://github.com/valkey-io/valkey/archive/unstable.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@unstable?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}],"relationships":[{"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"SPDXRef-Package--valkey-server"}]}' \
+		| sed -e "s|@SPDX_CREATED@|$SPDX_CREATED|g" -e "s|@SPDX_UUID@|$SPDX_UUID|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/unstable/debian/Dockerfile
+++ b/unstable/debian/Dockerfile
@@ -74,7 +74,7 @@ RUN set -eux; \
 	; \
 	\
 	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
-	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-unstable-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"unstable","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/unstable.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@unstable?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-unstable-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"unstable","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/unstable.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@unstable?os_name=debian&os_version=trixie"},{"referenceCategory":"SECURITY","referenceType":"cpe23Type","referenceLocator":"cpe:2.3:a:lfprojects:valkey:unstable:*:*:*:*:*:*:*"}],"licenseDeclared":"BSD-3-Clause"}]}' \
 		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base

--- a/unstable/debian/Dockerfile
+++ b/unstable/debian/Dockerfile
@@ -73,7 +73,9 @@ RUN set -eux; \
 		-exec ln -svfT 'valkey-server' '{}' ';' \
 	; \
 	\
-	echo '{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","packages":[{"name":"valkey-server","versionInfo":"unstable","SPDXID":"SPDXRef-Package--valkey-server","externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@unstable?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' > /usr/local/valkey.spdx.json
+	SPDX_CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; \
+	echo '{"spdxVersion":"SPDX-2.3","dataLicense":"CC0-1.0","SPDXID":"SPDXRef-DOCUMENT","name":"valkey-server-sbom","documentNamespace":"https://valkey.io/spdxdocs/valkey-server-sbom-unstable-@SPDX_CREATED@","creationInfo":{"created":"@SPDX_CREATED@","creators":["Organization: The Valkey Project","Tool: valkey-container"]},"packages":[{"name":"valkey-server","versionInfo":"unstable","SPDXID":"SPDXRef-Package--valkey-server","downloadLocation":"https://github.com/valkey-io/valkey/archive/unstable.tar.gz","filesAnalyzed":false,"externalRefs":[{"referenceCategory":"PACKAGE-MANAGER","referenceType":"purl","referenceLocator":"pkg:generic/valkey-server@unstable?os_name=debian&os_version=trixie"}],"licenseDeclared":"BSD-3-Clause"}]}' \
+		| sed "s|@SPDX_CREATED@|$SPDX_CREATED|g" > /usr/local/valkey.spdx.json
 
 FROM base
 

--- a/valkey-sbom.jq
+++ b/valkey-sbom.jq
@@ -46,11 +46,12 @@ def valkey_sbom:
 						referenceType: "purl",
 						referenceLocator: ("pkg:generic/" + .name + "@" + .version + "?" + (.params | [to_entries[] | .key + "=" + .value] | join("\u0026")))
 					},
-# "lfprojects:valkey" is the vendor:product pair NVD registers for Valkey
-# (e.g. cpe:2.3:a:lfprojects:valkey:8.1.1:*:*:*:*:*:*:*), so scanners can match
-# advisories against this package. The generic purl above is not matchable on
-# its own: it has no authoritative namespace and its name ("valkey-server")
-# differs from the NVD product name ("valkey").
+					# "lfprojects:valkey" is the vendor:product pair NVD registers for
+					# Valkey (e.g. cpe:2.3:a:lfprojects:valkey:8.1.1:*:*:*:*:*:*:*), so
+					# scanners can match advisories against this package. The generic
+					# purl above is not matchable on its own: it has no authoritative
+					# namespace and its name ("valkey-server") differs from the NVD
+					# product name ("valkey").
 					{
 						referenceCategory: "SECURITY",
 						referenceType: "cpe23Type",

--- a/valkey-sbom.jq
+++ b/valkey-sbom.jq
@@ -17,15 +17,43 @@
 # }
 # output: object
 #
-# The "@SPDX_CREATED@" token is substituted with the real build-time timestamp
-# in Dockerfile.template.
+# The "@SPDX_CREATED@" and "@SPDX_UUID@" tokens are substituted with the real
+# build-time timestamp and a fresh UUID in Dockerfile.template.
+
+# Split a Valkey version into the CPE 2.3 "version" and "update" components.
+# NVD records release candidates with the rcN in the update field, not in the
+# version field (e.g. cpe:2.3:a:lfprojects:valkey:7.2.4:rc1:*:*:*:*:*:* rather
+# than ...:valkey:7.2.4-rc1:*:...), so "9.1.0-rc2" has to become
+# version "9.1.0" + update "rc2" to correlate with NVD advisories.
+# GA releases use "*" for update: NVD is inconsistent between "-" and "*" there,
+# and advisory match criteria use "*" with version ranges.
+def _cpe_version_update:
+	if test("-rc[0-9]+$") then
+		{ version: sub("-rc[0-9]+$"; ""), update: ("rc" + capture("-rc(?<n>[0-9]+)$").n) }
+	else
+		{ version: ., update: "*" }
+	end
+;
+
 def valkey_sbom:
-    {
+	# "unstable" is a moving target with no corresponding NVD release, so a CPE
+	# built from it would be a fabricated identifier that matches nothing.
+	(if .version == "unstable" then null else (.version | _cpe_version_update) end) as $cpe
+	| {
 		spdxVersion: "SPDX-2.3",
 		dataLicense: "CC0-1.0",
 		SPDXID: "SPDXRef-DOCUMENT",
 		name: (.name + "-sbom"),
-		documentNamespace: ("https://valkey.io/spdxdocs/" + .name + "-sbom-" + .version + "-@SPDX_CREATED@"),
+		# The namespace must identify exactly one document globally. Name and
+		# version alone are not enough: the debian and alpine variants of one
+		# version are different documents, so the variant and a fresh UUID are
+		# included. The UUID (not the timestamp) is what guarantees uniqueness;
+		# creationInfo.created remains the human-readable creation time.
+		documentNamespace: (
+			"https://valkey.io/spdxdocs/" + .name + "-sbom-" + .version
+			+ "-" + (.params.os_name // "unknown") + "-" + (.params.os_version // "unknown")
+			+ "-@SPDX_UUID@"
+		),
 		creationInfo: {
 			created: "@SPDX_CREATED@",
 			creators: [
@@ -38,31 +66,43 @@ def valkey_sbom:
 				name: .name,
 				versionInfo: .version,
 				SPDXID: ("SPDXRef-Package--" + .name),
+				supplier: "Organization: The Valkey Project",
 				downloadLocation: (.downloadLocation // "NOASSERTION"),
 				filesAnalyzed: false,
-				externalRefs: [
+				externalRefs: ([
 					{
 						referenceCategory: "PACKAGE-MANAGER",
 						referenceType: "purl",
 						referenceLocator: ("pkg:generic/" + .name + "@" + .version + "?" + (.params | [to_entries[] | .key + "=" + .value] | join("\u0026")))
-					},
-					# "lfprojects:valkey" is the vendor:product pair NVD registers for
-					# Valkey (e.g. cpe:2.3:a:lfprojects:valkey:8.1.1:*:*:*:*:*:*:*), so
-					# scanners can match advisories against this package. The generic
-					# purl above is not matchable on its own: it has no authoritative
-					# namespace and its name ("valkey-server") differs from the NVD
-					# product name ("valkey").
-					{
-						referenceCategory: "SECURITY",
-						referenceType: "cpe23Type",
-						referenceLocator: ("cpe:2.3:a:lfprojects:valkey:" + .version + ":*:*:*:*:*:*:*")
 					}
-				],
+				] + (
+					# "lfprojects:valkey" is the vendor:product pair NVD registers
+					# for Valkey, so scanners can correlate this package with
+					# advisories. The generic purl above is not matchable on its
+					# own: it has no authoritative namespace and its name
+					# ("valkey-server") differs from the NVD product ("valkey").
+					if $cpe then [
+						{
+							referenceCategory: "SECURITY",
+							referenceType: "cpe23Type",
+							referenceLocator: ("cpe:2.3:a:lfprojects:valkey:" + $cpe.version + ":" + $cpe.update + ":*:*:*:*:*:*")
+						}
+					] else [] end
+				)),
 				licenseDeclared: (if .licenses | length > 0 then
 					(.licenses | join(" AND "))
 				else
 					"NOASSERTION"
 				end)
+			}
+		],
+		# State explicitly what this document describes, rather than leaving
+		# consumers to infer it from there being a single package.
+		relationships: [
+			{
+				spdxElementId: "SPDXRef-DOCUMENT",
+				relationshipType: "DESCRIBES",
+				relatedSpdxElement: ("SPDXRef-Package--" + .name)
 			}
 		]
 	}

--- a/valkey-sbom.jq
+++ b/valkey-sbom.jq
@@ -45,6 +45,16 @@ def valkey_sbom:
 						referenceCategory: "PACKAGE-MANAGER",
 						referenceType: "purl",
 						referenceLocator: ("pkg:generic/" + .name + "@" + .version + "?" + (.params | [to_entries[] | .key + "=" + .value] | join("\u0026")))
+					},
+# "lfprojects:valkey" is the vendor:product pair NVD registers for Valkey
+# (e.g. cpe:2.3:a:lfprojects:valkey:8.1.1:*:*:*:*:*:*:*), so scanners can match
+# advisories against this package. The generic purl above is not matchable on
+# its own: it has no authoritative namespace and its name ("valkey-server")
+# differs from the NVD product name ("valkey").
+					{
+						referenceCategory: "SECURITY",
+						referenceType: "cpe23Type",
+						referenceLocator: ("cpe:2.3:a:lfprojects:valkey:" + .version + ":*:*:*:*:*:*:*")
 					}
 				],
 				licenseDeclared: (if .licenses | length > 0 then

--- a/valkey-sbom.jq
+++ b/valkey-sbom.jq
@@ -1,0 +1,58 @@
+# Valkey-specific replacement for bashbrew's stock "sbom" template helper.
+#
+# The stock helper (auto-downloaded, gitignored .template-helper-functions.jq)
+# omits fields that SPDX 2.3 marks mandatory, so strict scanners reject the
+# resulting document (https://github.com/valkey-io/valkey-container/issues/114).
+# This tracked module produces a minimal but spec-compliant SPDX 2.3 document.
+#
+# input:
+# {
+#     name: "packageName",
+#     version: "packageVersion",
+#     downloadLocation: "https://.../source.tar.gz",
+#     params: {
+#         "foo": "bar"
+#     },
+#     licenses: ["packageLicense" ... ]
+# }
+# output: object
+#
+# The "@SPDX_CREATED@" token is substituted with the real build-time timestamp
+# in Dockerfile.template.
+def valkey_sbom:
+    {
+		spdxVersion: "SPDX-2.3",
+		dataLicense: "CC0-1.0",
+		SPDXID: "SPDXRef-DOCUMENT",
+		name: (.name + "-sbom"),
+		documentNamespace: ("https://valkey.io/spdxdocs/" + .name + "-sbom-" + .version + "-@SPDX_CREATED@"),
+		creationInfo: {
+			created: "@SPDX_CREATED@",
+			creators: [
+				"Organization: The Valkey Project",
+				"Tool: valkey-container"
+			]
+		},
+		packages: [
+			{
+				name: .name,
+				versionInfo: .version,
+				SPDXID: ("SPDXRef-Package--" + .name),
+				downloadLocation: (.downloadLocation // "NOASSERTION"),
+				filesAnalyzed: false,
+				externalRefs: [
+					{
+						referenceCategory: "PACKAGE-MANAGER",
+						referenceType: "purl",
+						referenceLocator: ("pkg:generic/" + .name + "@" + .version + "?" + (.params | [to_entries[] | .key + "=" + .value] | join("\u0026")))
+					}
+				],
+				licenseDeclared: (if .licenses | length > 0 then
+					(.licenses | join(" AND "))
+				else
+					"NOASSERTION"
+				end)
+			}
+		]
+	}
+;


### PR DESCRIPTION
Fixes #114

The SBOM at `/usr/local/valkey.spdx.json` was missing fields that SPDX 2.3 marks mandatory, so strict scanners like Nexus IQ reject it with "SPDX content cannot be parsed".

Changes:
- Add the missing mandatory fields (`dataLicense`, `documentNamespace`, `creationInfo`, package `downloadLocation`, `filesAnalyzed: false`). Build time is stamped into `created` and the namespace for a unique per-build document ID.
- Move SBOM generation into a tracked `valkey-sbom.jq` (the old document came from bashbrew's auto-downloaded, gitignored stock helper).
- Add a `valkey-sbom` test validating the shipped SBOM with the spdx-tools validator.