### PR TITLE
Add immutable CVE candidate verification and promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
 name: GitHub CI
-run-name: ${{ inputs.correlation_id != '' && format('CVE rebuild {0}', inputs.correlation_id) || github.event.pull_request.title || github.event.head_commit.message || github.workflow }}
 
 on:
   pull_request:
@@ -12,16 +11,6 @@ on:
         description: 'Versions to build and push, space-separated (ex: "9.0.2" or "9.0.2 8.1.5" or unstable)'
         required: true
         type: string
-      correlation_id:
-        description: 'Unique CVE rebuild identifier; enables build-verify-promote mode'
-        required: false
-        type: string
-        default: ''
-      targeted_findings:
-        description: 'Base64 JSON list of targeted CVE/package/platform findings'
-        required: false
-        type: string
-        default: ''
 
 env:
   PUBLISH_DOCKERHUB: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' && github.ref == 'refs/heads/mainline' }}
@@ -56,10 +45,6 @@ jobs:
           echo "publish_ecr=$PUBLISH_ECR" >> "$GITHUB_OUTPUT"
       - id: generate-jobs
         name: Generate Jobs
-        env:
-          VERSION_INPUT: ${{ inputs.version }}
-          CVE_CORRELATION_ID: ${{ inputs.correlation_id }}
-          CVE_TARGETS_B64: ${{ inputs.targeted_findings }}
         run: |
           # Generate full strategy for testing all versions
           test_strategy="$("$BASHBREW_SCRIPTS/github-actions/generate.sh")"
@@ -70,48 +55,11 @@ jobs:
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
             publish_strategy=$(jq -c '{"fail-fast": .["fail-fast"],"matrix":{"include":[ .matrix.include[]|select(.name =="unstable" or .name== "unstable-alpine")]}}' <<<"$publish_strategy")
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            if [[ -n "$CVE_CORRELATION_ID" ]]; then
-              [[ -n "$CVE_TARGETS_B64" ]] || { echo "CVE rebuild requires targeted_findings" >&2; exit 1; }
-              targets_json=$(printf '%s' "$CVE_TARGETS_B64" | base64 --decode)
-              target_names=$(jq -ce '
-                if type != "array" or length == 0 then error("targets must be a non-empty list") else . end
-                | [ .[] | .image | select(type == "string") | split(":")[-1] ]
-                | unique
-                | if length == 0 then error("targets contain no image tags") else . end
-              ' <<<"$targets_json")
-              publish_strategy=$(jq -c --argjson names "$target_names" '
-                def matches_target($entry; $target):
-                  any($entry.meta.entries[0].tags[]; . == ("valkey-container:" + $target));
-                . as $strategy
-                | [
-                    $names[] as $target
-                    | {
-                        target: $target,
-                        matches: [
-                          $strategy.matrix.include[]
-                          | select(matches_target(.; $target))
-                        ]
-                      }
-                  ] as $resolved
-                | if any($resolved[]; (.matches | length) != 1)
-                  then error("every target image must map to exactly one build matrix entry")
-                  else {
-                    "fail-fast": $strategy["fail-fast"],
-                    "matrix": {"include": [$resolved[].matches[]] | unique_by(.name)}
-                  }
-                  end
-              ' <<<"$publish_strategy")
-              [[ "$(jq '.matrix.include | length' <<<"$publish_strategy")" -gt 0 ]] || {
-                echo "No build matrix entries match the targeted findings" >&2
-                exit 1
-              }
-              # A CVE rebuild tests exactly the candidate variants that may be promoted.
-              test_strategy="$publish_strategy"
-            else
-              # Normal manual build: preserve the existing version-pattern behavior.
-              version_pattern=$(echo "$VERSION_INPUT" | xargs | tr ' ' '|')
-              publish_strategy=$(jq -c --arg version "$version_pattern" '{"fail-fast": .["fail-fast"],"matrix":{"include":[ .matrix.include[]|select(.name | test($version))]}}' <<<"$publish_strategy")
-            fi
+            # If triggered by a workflow dispatch, build only the specified version(s)
+            # Space-separated version (e.g. "9.0.2 8.1.5 unstable")
+            version_input="${{ github.event.inputs.version }}"
+            version_pattern=$(echo "$version_input" | xargs | tr ' ' '|')
+            publish_strategy=$(jq -c --arg version "$version_pattern" '{"fail-fast": .["fail-fast"],"matrix":{"include":[ .matrix.include[]|select(.name | test($version))]}}' <<<"$publish_strategy")
           elif [[ ("${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/mainline") || ("${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "mainline") ]]; then
             # For pushes to mainline or PRs targeting mainline, only build changed versions
             if [[ "${{ github.event_name }}" == "pull_request" ]]; then
@@ -139,13 +87,6 @@ jobs:
           echo "Publish Strategy:"
           jq . <<<"$publish_strategy" # sanity check / debugging aid
 
-  cve-script-tests:
-    name: Test CVE candidate scripts
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - run: python -m unittest discover -s tests -p 'test_*.py' -v
-
   test:
     needs: generate-jobs
     strategy: ${{ fromJson(needs.generate-jobs.outputs.test_strategy) }}
@@ -170,7 +111,6 @@ jobs:
     if: |
       ((github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       github.ref == 'refs/heads/mainline' &&
-      inputs.correlation_id == '' &&
       fromJson(needs.generate-jobs.outputs.publish_strategy).matrix.include[0] &&
       (needs.generate-jobs.outputs.publish_dockerhub == 'true' || needs.generate-jobs.outputs.publish_ghcr == 'true' || needs.generate-jobs.outputs.publish_ecr == 'true'))
     needs:
@@ -253,209 +193,6 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
           provenance: false
           load: false
-
-  cve-build-verify:
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      inputs.correlation_id != '' &&
-      github.repository == 'valkey-io/valkey-container' &&
-      github.ref == 'refs/heads/mainline' &&
-      fromJson(needs.generate-jobs.outputs.publish_strategy).matrix.include[0]
-    needs:
-      - generate-jobs
-      - test
-      - cve-script-tests
-    strategy: ${{ fromJson(needs.generate-jobs.outputs.publish_strategy) }}
-    name: ${{ matrix.name }} - Build and verify CVE candidate
-    runs-on: ${{ matrix.os }}
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Define immutable candidate destination
-        id: candidate
-        env:
-          CORRELATION_ID: ${{ inputs.correlation_id }}
-          IMAGE_NAME: ${{ matrix.name }}
-        run: |
-          [[ "$CORRELATION_ID" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "Invalid correlation ID" >&2; exit 1; }
-          safe_name=$(sed 's/[^A-Za-z0-9_.-]/-/g' <<<"$IMAGE_NAME")
-          repository="ghcr.io/${{ github.repository_owner }}/valkey"
-          reference="${repository}:cve-candidate-${CORRELATION_ID}-${safe_name}"
-          echo "repository=${repository}" >> "$GITHUB_OUTPUT"
-          echo "reference=${reference}" >> "$GITHUB_OUTPUT"
-          echo "safe_name=${safe_name}" >> "$GITHUB_OUTPUT"
-
-      - name: Build and push candidate without production tags
-        id: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: .
-          file: ./${{ matrix.meta.entries[0].directory }}/Dockerfile
-          push: true
-          tags: ${{ steps.candidate.outputs.reference }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
-          provenance: false
-
-      - name: Confirm all published platforms are in the candidate
-        id: manifest
-        env:
-          CANDIDATE: ${{ steps.candidate.outputs.repository }}@${{ steps.build.outputs.digest }}
-        run: |
-          manifest=$(docker buildx imagetools inspect --raw "$CANDIDATE")
-          actual=$(jq -r '[.manifests[].platform | .os + "/" + .architecture + (if .variant then "/" + .variant else "" end)] | sort | .[]' <<<"$manifest")
-          expected=$'linux/amd64\nlinux/arm/v7\nlinux/arm64\nlinux/ppc64le'
-          [[ "$actual" == "$expected" ]] || {
-            echo "Candidate platform set does not match the published platform set" >&2
-            diff -u <(printf '%s\n' "$expected") <(printf '%s\n' "$actual") || true
-            exit 1
-          }
-          platform_digests=$(jq -ce '
-            [.manifests[] | {
-              key: (.platform.os + "/" + .platform.architecture + (if .platform.variant then "/" + .platform.variant else "" end)),
-              value: .digest
-            }] | from_entries
-          ' <<<"$manifest")
-          echo "platform_digests=${platform_digests}" >> "$GITHUB_OUTPUT"
-
-      - name: Install Trivy
-        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
-        with:
-          version: v0.72.0
-
-      - name: Verify targeted findings are absent from the exact candidate digest
-        env:
-          CANDIDATE: ${{ steps.candidate.outputs.repository }}@${{ steps.build.outputs.digest }}
-          IMAGE_NAME: ${{ matrix.name }}
-          CANDIDATE_TAGS_JSON: ${{ toJson(matrix.meta.entries[0].tags) }}
-          TARGETS_B64: ${{ inputs.targeted_findings }}
-        run: |
-          python scripts/cve/verify_candidate.py \
-            --candidate "$CANDIDATE" \
-            --image-tag "$IMAGE_NAME" \
-            --candidate-tags-json "$CANDIDATE_TAGS_JSON" \
-            --targets-b64 "$TARGETS_B64"
-
-      - name: Record verified candidate metadata
-        env:
-          IMAGE_NAME: ${{ matrix.name }}
-          REPOSITORY: ${{ steps.candidate.outputs.repository }}
-          DIGEST: ${{ steps.build.outputs.digest }}
-          ORIGINAL_TAGS: ${{ toJson(matrix.meta.entries[0].tags) }}
-          PLATFORM_DIGESTS: ${{ steps.manifest.outputs.platform_digests }}
-          SAFE_NAME: ${{ steps.candidate.outputs.safe_name }}
-        run: |
-          mkdir -p candidate-metadata
-          jq -n \
-            --arg name "$IMAGE_NAME" \
-            --arg repository "$REPOSITORY" \
-            --arg digest "$DIGEST" \
-            --argjson tags "$ORIGINAL_TAGS" \
-            --argjson platform_digests "$PLATFORM_DIGESTS" \
-            '{name: $name, repository: $repository, digest: $digest, tags: $tags, platform_digests: $platform_digests}' \
-            > "candidate-metadata/${SAFE_NAME}.json"
-
-      - name: Upload verified candidate metadata
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: cve-candidate-${{ steps.candidate.outputs.safe_name }}
-          path: candidate-metadata/*.json
-          if-no-files-found: error
-
-  cve-promote:
-    if: |
-      github.event_name == 'workflow_dispatch' &&
-      inputs.correlation_id != '' &&
-      github.repository == 'valkey-io/valkey-container' &&
-      github.ref == 'refs/heads/mainline'
-    needs:
-      - generate-jobs
-      - cve-build-verify
-    name: Promote verified CVE candidates
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Download verified candidate metadata
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: cve-candidate-*
-          path: candidate-metadata
-          merge-multiple: true
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Login to Docker Hub
-        if: needs.generate-jobs.outputs.publish_dockerhub == 'true'
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Configure AWS credentials via OIDC
-        if: needs.generate-jobs.outputs.publish_ecr == 'true'
-        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: us-east-1
-
-      - name: Login to Amazon ECR Public Gallery
-        if: needs.generate-jobs.outputs.publish_ecr == 'true'
-        run: |
-          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
-
-      - name: Install registry promotion tool
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends skopeo
-
-      - name: Promote the verified digests to production tags
-        env:
-          GHCR_REPOSITORY: ghcr.io/${{ github.repository_owner }}/valkey
-          DOCKERHUB_REPOSITORY: ${{ needs.generate-jobs.outputs.publish_dockerhub == 'true' && format('docker.io/{0}/valkey', secrets.DOCKERHUB_ACCOUNT) || '' }}
-          ECR_REPOSITORY: ${{ needs.generate-jobs.outputs.publish_ecr == 'true' && format('public.ecr.aws/{0}/valkey', secrets.ECR_REGISTRY_ALIAS) || '' }}
-          CORRELATION_ID: ${{ inputs.correlation_id }}
-        run: |
-          python scripts/cve/promote_candidates.py \
-            --metadata-dir candidate-metadata \
-            --correlation-id "$CORRELATION_ID"
-
-      - name: Promotion summary
-        env:
-          CORRELATION_ID: ${{ inputs.correlation_id }}
-        run: |
-          {
-            echo "## CVE candidate promotion"
-            echo
-            echo "Correlation ID: \`$CORRELATION_ID\`"
-            echo
-            echo "Every targeted platform finding was absent from the immutable candidates before their exact digests were promoted."
-          } >> "$GITHUB_STEP_SUMMARY"
 
   update-dockerhub-ecr-description-file:
     if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: GitHub CI
+run-name: ${{ inputs.correlation_id != '' && format('CVE rebuild {0}', inputs.correlation_id) || github.event.pull_request.title || github.event.head_commit.message || github.workflow }}
 
 on:
   pull_request:
@@ -11,6 +12,16 @@ on:
         description: 'Versions to build and push, space-separated (ex: "9.0.2" or "9.0.2 8.1.5" or unstable)'
         required: true
         type: string
+      correlation_id:
+        description: 'Unique CVE rebuild identifier; enables build-verify-promote mode'
+        required: false
+        type: string
+        default: ''
+      targeted_findings:
+        description: 'Base64 JSON list of targeted CVE/package/platform findings'
+        required: false
+        type: string
+        default: ''
 
 env:
   PUBLISH_DOCKERHUB: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' && github.ref == 'refs/heads/mainline' }}
@@ -45,6 +56,10 @@ jobs:
           echo "publish_ecr=$PUBLISH_ECR" >> "$GITHUB_OUTPUT"
       - id: generate-jobs
         name: Generate Jobs
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
+          CVE_CORRELATION_ID: ${{ inputs.correlation_id }}
+          CVE_TARGETS_B64: ${{ inputs.targeted_findings }}
         run: |
           # Generate full strategy for testing all versions
           test_strategy="$("$BASHBREW_SCRIPTS/github-actions/generate.sh")"
@@ -55,11 +70,55 @@ jobs:
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
             publish_strategy=$(jq -c '{"fail-fast": .["fail-fast"],"matrix":{"include":[ .matrix.include[]|select(.name =="unstable" or .name== "unstable-alpine")]}}' <<<"$publish_strategy")
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            # If triggered by a workflow dispatch, build only the specified version(s)
-            # Space-separated version (e.g. "9.0.2 8.1.5 unstable")
-            version_input="${{ github.event.inputs.version }}"
-            version_pattern=$(echo "$version_input" | xargs | tr ' ' '|')
-            publish_strategy=$(jq -c --arg version "$version_pattern" '{"fail-fast": .["fail-fast"],"matrix":{"include":[ .matrix.include[]|select(.name | test($version))]}}' <<<"$publish_strategy")
+            if [[ -n "$CVE_CORRELATION_ID" ]]; then
+              [[ -n "$CVE_TARGETS_B64" ]] || { echo "CVE rebuild requires targeted_findings" >&2; exit 1; }
+              targets_json=$(printf '%s' "$CVE_TARGETS_B64" | base64 --decode)
+              target_names=$(jq -ce '
+                if type != "array" or length == 0 then error("targets must be a non-empty list") else . end
+                | [ .[] | .image | select(type == "string") | split(":")[-1] ]
+                | unique
+                | if length == 0 then error("targets contain no image tags") else . end
+              ' <<<"$targets_json")
+              publish_strategy=$(jq -c --argjson names "$target_names" '
+                def matches_target($name; $target):
+                  if $name == $target then true
+                  elif ($target | test("^[0-9]+\\.[0-9]+-alpine$")) then
+                    ($target | sub("-alpine$"; "")) as $line
+                    | ($name | startswith($line + ".")) and ($name | endswith("-alpine"))
+                  elif ($target | test("^[0-9]+\\.[0-9]+$")) then
+                    ($name | startswith($target + ".")) and (($name | endswith("-alpine")) | not)
+                  else false
+                  end;
+                . as $strategy
+                | [
+                    $names[] as $target
+                    | {
+                        target: $target,
+                        matches: [
+                          $strategy.matrix.include[]
+                          | select(matches_target(.name; $target))
+                        ]
+                      }
+                  ] as $resolved
+                | if any($resolved[]; (.matches | length) != 1)
+                  then error("every target image must map to exactly one build matrix entry")
+                  else {
+                    "fail-fast": $strategy["fail-fast"],
+                    "matrix": {"include": [$resolved[].matches[]] | unique_by(.name)}
+                  }
+                  end
+              ' <<<"$publish_strategy")
+              [[ "$(jq '.matrix.include | length' <<<"$publish_strategy")" -gt 0 ]] || {
+                echo "No build matrix entries match the targeted findings" >&2
+                exit 1
+              }
+              # A CVE rebuild tests exactly the candidate variants that may be promoted.
+              test_strategy="$publish_strategy"
+            else
+              # Normal manual build: preserve the existing version-pattern behavior.
+              version_pattern=$(echo "$VERSION_INPUT" | xargs | tr ' ' '|')
+              publish_strategy=$(jq -c --arg version "$version_pattern" '{"fail-fast": .["fail-fast"],"matrix":{"include":[ .matrix.include[]|select(.name | test($version))]}}' <<<"$publish_strategy")
+            fi
           elif [[ ("${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/mainline") || ("${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "mainline") ]]; then
             # For pushes to mainline or PRs targeting mainline, only build changed versions
             if [[ "${{ github.event_name }}" == "pull_request" ]]; then
@@ -87,6 +146,13 @@ jobs:
           echo "Publish Strategy:"
           jq . <<<"$publish_strategy" # sanity check / debugging aid
 
+  cve-script-tests:
+    name: Test CVE candidate scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - run: python -m unittest discover -s tests -p 'test_*.py' -v
+
   test:
     needs: generate-jobs
     strategy: ${{ fromJson(needs.generate-jobs.outputs.test_strategy) }}
@@ -111,6 +177,7 @@ jobs:
     if: |
       ((github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       github.ref == 'refs/heads/mainline' &&
+      inputs.correlation_id == '' &&
       fromJson(needs.generate-jobs.outputs.publish_strategy).matrix.include[0] &&
       (needs.generate-jobs.outputs.publish_dockerhub == 'true' || needs.generate-jobs.outputs.publish_ghcr == 'true' || needs.generate-jobs.outputs.publish_ecr == 'true'))
     needs:
@@ -193,6 +260,207 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
           provenance: false
           load: false
+
+  cve-build-verify:
+    if: |
+      github.event_name == 'workflow_dispatch' &&
+      inputs.correlation_id != '' &&
+      github.repository == 'valkey-io/valkey-container' &&
+      github.ref == 'refs/heads/mainline' &&
+      fromJson(needs.generate-jobs.outputs.publish_strategy).matrix.include[0]
+    needs:
+      - generate-jobs
+      - test
+      - cve-script-tests
+    strategy: ${{ fromJson(needs.generate-jobs.outputs.publish_strategy) }}
+    name: ${{ matrix.name }} - Build and verify CVE candidate
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Define immutable candidate destination
+        id: candidate
+        env:
+          CORRELATION_ID: ${{ inputs.correlation_id }}
+          IMAGE_NAME: ${{ matrix.name }}
+        run: |
+          [[ "$CORRELATION_ID" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "Invalid correlation ID" >&2; exit 1; }
+          safe_name=$(sed 's/[^A-Za-z0-9_.-]/-/g' <<<"$IMAGE_NAME")
+          repository="ghcr.io/${{ github.repository_owner }}/valkey"
+          reference="${repository}:cve-candidate-${CORRELATION_ID}-${safe_name}"
+          echo "repository=${repository}" >> "$GITHUB_OUTPUT"
+          echo "reference=${reference}" >> "$GITHUB_OUTPUT"
+          echo "safe_name=${safe_name}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push candidate without production tags
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./${{ matrix.meta.entries[0].directory }}/Dockerfile
+          push: true
+          tags: ${{ steps.candidate.outputs.reference }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
+          provenance: false
+
+      - name: Confirm all published platforms are in the candidate
+        id: manifest
+        env:
+          CANDIDATE: ${{ steps.candidate.outputs.repository }}@${{ steps.build.outputs.digest }}
+        run: |
+          manifest=$(docker buildx imagetools inspect --raw "$CANDIDATE")
+          actual=$(jq -r '[.manifests[].platform | .os + "/" + .architecture + (if .variant then "/" + .variant else "" end)] | sort | .[]' <<<"$manifest")
+          expected=$'linux/amd64\nlinux/arm/v7\nlinux/arm64\nlinux/ppc64le'
+          [[ "$actual" == "$expected" ]] || {
+            echo "Candidate platform set does not match the published platform set" >&2
+            diff -u <(printf '%s\n' "$expected") <(printf '%s\n' "$actual") || true
+            exit 1
+          }
+          platform_digests=$(jq -ce '
+            [.manifests[] | {
+              key: (.platform.os + "/" + .platform.architecture + (if .platform.variant then "/" + .platform.variant else "" end)),
+              value: .digest
+            }] | from_entries
+          ' <<<"$manifest")
+          echo "platform_digests=${platform_digests}" >> "$GITHUB_OUTPUT"
+
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
+        with:
+          version: v0.72.0
+
+      - name: Verify targeted findings are absent from the exact candidate digest
+        env:
+          CANDIDATE: ${{ steps.candidate.outputs.repository }}@${{ steps.build.outputs.digest }}
+          IMAGE_NAME: ${{ matrix.name }}
+          TARGETS_B64: ${{ inputs.targeted_findings }}
+        run: |
+          python scripts/cve/verify_candidate.py \
+            --candidate "$CANDIDATE" \
+            --image-tag "$IMAGE_NAME" \
+            --targets-b64 "$TARGETS_B64"
+
+      - name: Record verified candidate metadata
+        env:
+          IMAGE_NAME: ${{ matrix.name }}
+          REPOSITORY: ${{ steps.candidate.outputs.repository }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+          ORIGINAL_TAGS: ${{ toJson(matrix.meta.entries[0].tags) }}
+          PLATFORM_DIGESTS: ${{ steps.manifest.outputs.platform_digests }}
+          SAFE_NAME: ${{ steps.candidate.outputs.safe_name }}
+        run: |
+          mkdir -p candidate-metadata
+          jq -n \
+            --arg name "$IMAGE_NAME" \
+            --arg repository "$REPOSITORY" \
+            --arg digest "$DIGEST" \
+            --argjson tags "$ORIGINAL_TAGS" \
+            --argjson platform_digests "$PLATFORM_DIGESTS" \
+            '{name: $name, repository: $repository, digest: $digest, tags: $tags, platform_digests: $platform_digests}' \
+            > "candidate-metadata/${SAFE_NAME}.json"
+
+      - name: Upload verified candidate metadata
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cve-candidate-${{ steps.candidate.outputs.safe_name }}
+          path: candidate-metadata/*.json
+          if-no-files-found: error
+
+  cve-promote:
+    if: |
+      github.event_name == 'workflow_dispatch' &&
+      inputs.correlation_id != '' &&
+      github.repository == 'valkey-io/valkey-container' &&
+      github.ref == 'refs/heads/mainline'
+    needs:
+      - generate-jobs
+      - cve-build-verify
+    name: Promote verified CVE candidates
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Download verified candidate metadata
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: cve-candidate-*
+          path: candidate-metadata
+          merge-multiple: true
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Login to Docker Hub
+        if: needs.generate-jobs.outputs.publish_dockerhub == 'true'
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Configure AWS credentials via OIDC
+        if: needs.generate-jobs.outputs.publish_ecr == 'true'
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR Public Gallery
+        if: needs.generate-jobs.outputs.publish_ecr == 'true'
+        run: |
+          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+
+      - name: Install registry promotion tool
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends skopeo
+
+      - name: Promote the verified digests to production tags
+        env:
+          GHCR_REPOSITORY: ghcr.io/${{ github.repository_owner }}/valkey
+          DOCKERHUB_REPOSITORY: ${{ needs.generate-jobs.outputs.publish_dockerhub == 'true' && format('docker.io/{0}/valkey', secrets.DOCKERHUB_ACCOUNT) || '' }}
+          ECR_REPOSITORY: ${{ needs.generate-jobs.outputs.publish_ecr == 'true' && format('public.ecr.aws/{0}/valkey', secrets.ECR_REGISTRY_ALIAS) || '' }}
+          CORRELATION_ID: ${{ inputs.correlation_id }}
+        run: |
+          python scripts/cve/promote_candidates.py \
+            --metadata-dir candidate-metadata \
+            --correlation-id "$CORRELATION_ID"
+
+      - name: Promotion summary
+        env:
+          CORRELATION_ID: ${{ inputs.correlation_id }}
+        run: |
+          {
+            echo "## CVE candidate promotion"
+            echo
+            echo "Correlation ID: \`$CORRELATION_ID\`"
+            echo
+            echo "Every targeted platform finding was absent from the immutable candidates before their exact digests were promoted."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   update-dockerhub-ecr-description-file:
     if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,15 +80,8 @@ jobs:
                 | if length == 0 then error("targets contain no image tags") else . end
               ' <<<"$targets_json")
               publish_strategy=$(jq -c --argjson names "$target_names" '
-                def matches_target($name; $target):
-                  if $name == $target then true
-                  elif ($target | test("^[0-9]+\\.[0-9]+-alpine$")) then
-                    ($target | sub("-alpine$"; "")) as $line
-                    | ($name | startswith($line + ".")) and ($name | endswith("-alpine"))
-                  elif ($target | test("^[0-9]+\\.[0-9]+$")) then
-                    ($name | startswith($target + ".")) and (($name | endswith("-alpine")) | not)
-                  else false
-                  end;
+                def matches_target($entry; $target):
+                  any($entry.meta.entries[0].tags[]; . == ("valkey-container:" + $target));
                 . as $strategy
                 | [
                     $names[] as $target
@@ -96,7 +89,7 @@ jobs:
                         target: $target,
                         matches: [
                           $strategy.matrix.include[]
-                          | select(matches_target(.name; $target))
+                          | select(matches_target(.; $target))
                         ]
                       }
                   ] as $resolved
@@ -349,11 +342,13 @@ jobs:
         env:
           CANDIDATE: ${{ steps.candidate.outputs.repository }}@${{ steps.build.outputs.digest }}
           IMAGE_NAME: ${{ matrix.name }}
+          CANDIDATE_TAGS_JSON: ${{ toJson(matrix.meta.entries[0].tags) }}
           TARGETS_B64: ${{ inputs.targeted_findings }}
         run: |
           python scripts/cve/verify_candidate.py \
             --candidate "$CANDIDATE" \
             --image-tag "$IMAGE_NAME" \
+            --candidate-tags-json "$CANDIDATE_TAGS_JSON" \
             --targets-b64 "$TARGETS_B64"
 
       - name: Record verified candidate metadata

--- a/.github/workflows/cve-rebuild.yml
+++ b/.github/workflows/cve-rebuild.yml
@@ -1,0 +1,353 @@
+name: CVE Candidate Rebuild
+run-name: ${{ inputs.correlation_id != '' && format('CVE rebuild {0}', inputs.correlation_id) || 'CVE candidate checks' }}
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/cve-rebuild.yml'
+      - 'scripts/cve/**'
+      - 'tests/test_cve_candidate.py'
+  push:
+    paths:
+      - '.github/workflows/cve-rebuild.yml'
+      - 'scripts/cve/**'
+      - 'tests/test_cve_candidate.py'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Affected version lines, space-separated (for example: "9.0 8.1")'
+        required: true
+        type: string
+      correlation_id:
+        description: 'Unique identifier supplied by valkey-ci-agent'
+        required: true
+        type: string
+      targeted_findings:
+        description: 'Base64 JSON list of targeted CVE/package/platform findings'
+        required: true
+        type: string
+
+env:
+  PUBLISH_DOCKERHUB: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' && github.ref == 'refs/heads/mainline' }}
+  PUBLISH_GHCR: ${{ github.repository == 'valkey-io/valkey-container' && github.ref == 'refs/heads/mainline' }}
+  PUBLISH_ECR: ${{ secrets.AWS_ROLE_TO_ASSUME != '' && github.ref == 'refs/heads/mainline' }}
+
+defaults:
+  run:
+    shell: 'bash -Eeuo pipefail {0}'
+
+permissions:
+  contents: read
+
+jobs:
+  generate-jobs:
+    if: github.event_name == 'workflow_dispatch'
+    name: Resolve targeted variants
+    runs-on: ubuntu-latest
+    outputs:
+      strategy: ${{ steps.generate-jobs.outputs.strategy }}
+      publish_dockerhub: ${{ steps.check-secrets.outputs.publish_dockerhub }}
+      publish_ghcr: ${{ steps.check-secrets.outputs.publish_ghcr }}
+      publish_ecr: ${{ steps.check-secrets.outputs.publish_ecr }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: docker-library/bashbrew@a519e31d2ed9cb229ff38ab4488e78bfa09d7a2a # v0.1.14
+      - id: check-secrets
+        name: Output publish flags for downstream jobs
+        run: |
+          echo "publish_dockerhub=$PUBLISH_DOCKERHUB" >> "$GITHUB_OUTPUT"
+          echo "publish_ghcr=$PUBLISH_GHCR" >> "$GITHUB_OUTPUT"
+          echo "publish_ecr=$PUBLISH_ECR" >> "$GITHUB_OUTPUT"
+      - id: generate-jobs
+        name: Match findings to generated image aliases
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
+          TARGETS_B64: ${{ inputs.targeted_findings }}
+        run: |
+          full_strategy="$("$BASHBREW_SCRIPTS/github-actions/generate.sh")"
+          targets_json=$(printf '%s' "$TARGETS_B64" | base64 --decode)
+
+          target_names=$(jq -ce '
+            if type != "array" or length == 0
+            then error("targets must be a non-empty list")
+            else .
+            end
+            | if all(.[ ];
+                type == "object"
+                and (.image | type == "string" and startswith("valkey/valkey:") and length > 14)
+                and (.cve_id | type == "string" and length > 0)
+                and (.package | type == "string" and length > 0)
+                and (.platform | IN("linux/amd64", "linux/arm64", "linux/arm/v7", "linux/ppc64le"))
+              )
+              then [.[].image | sub("^valkey/valkey:"; "")] | unique
+              else error("each target must contain a valid image, CVE, package, and published platform")
+              end
+          ' <<<"$targets_json")
+
+          requested_versions=$(jq -cn --arg versions "$VERSION_INPUT" '$versions | [scan("\\S+")] | unique')
+          target_versions=$(jq -c '[.[] | sub("-alpine$"; "")] | unique' <<<"$target_names")
+          [[ "$requested_versions" == "$target_versions" ]] || {
+            echo "Affected version lines do not exactly match targeted image aliases" >&2
+            echo "requested: $requested_versions" >&2
+            echo "targeted:  $target_versions" >&2
+            exit 1
+          }
+
+          strategy=$(jq -c --argjson names "$target_names" '
+            def matches_target($entry; $target):
+              any($entry.meta.entries[0].tags[]; . == ("valkey-container:" + $target));
+            . as $strategy
+            | [
+                $names[] as $target
+                | {
+                    target: $target,
+                    matches: [
+                      $strategy.matrix.include[]
+                      | select(matches_target(.; $target))
+                    ]
+                  }
+              ] as $resolved
+            | if any($resolved[]; (.matches | length) != 1)
+              then error("every target image must map to exactly one build matrix entry")
+              else {
+                "fail-fast": $strategy["fail-fast"],
+                "matrix": {"include": [$resolved[].matches[]] | unique_by(.name)}
+              }
+              end
+          ' <<<"$full_strategy")
+
+          [[ "$(jq '.matrix.include | length' <<<"$strategy")" -gt 0 ]] || {
+            echo "No build matrix entries match the targeted findings" >&2
+            exit 1
+          }
+          echo "strategy=$strategy" >> "$GITHUB_OUTPUT"
+          jq . <<<"$strategy"
+
+  cve-script-tests:
+    name: Test CVE candidate scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - run: python -m unittest discover -s tests -p 'test_*.py' -v
+
+  test:
+    if: github.event_name == 'workflow_dispatch'
+    needs: generate-jobs
+    strategy: ${{ fromJson(needs.generate-jobs.outputs.strategy) }}
+    name: ${{ matrix.name }} - test
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Prepare Environment
+        run: ${{ matrix.runs.prepare }}
+      - name: Pull Dependencies
+        run: ${{ matrix.runs.pull }}
+      - name: Build ${{ matrix.name }}
+        run: ${{ matrix.runs.build }}
+      - name: History ${{ matrix.name }}
+        run: ${{ matrix.runs.history }}
+      - name: Test ${{ matrix.name }}
+        run: ${{ matrix.runs.test }}
+      - name: '"docker images"'
+        run: ${{ matrix.runs.images }}
+
+  build-verify:
+    if: |
+      github.event_name == 'workflow_dispatch' &&
+      github.repository == 'valkey-io/valkey-container' &&
+      github.ref == 'refs/heads/mainline' &&
+      fromJson(needs.generate-jobs.outputs.strategy).matrix.include[0]
+    needs:
+      - generate-jobs
+      - cve-script-tests
+      - test
+    strategy: ${{ fromJson(needs.generate-jobs.outputs.strategy) }}
+    name: ${{ matrix.name }} - Build and verify CVE candidate
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Define immutable candidate destination
+        id: candidate
+        env:
+          CORRELATION_ID: ${{ inputs.correlation_id }}
+          IMAGE_NAME: ${{ matrix.name }}
+        run: |
+          [[ "$CORRELATION_ID" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "Invalid correlation ID" >&2; exit 1; }
+          safe_name=$(sed 's/[^A-Za-z0-9_.-]/-/g' <<<"$IMAGE_NAME")
+          repository="ghcr.io/${{ github.repository_owner }}/valkey"
+          reference="${repository}:cve-candidate-${CORRELATION_ID}-${safe_name}"
+          echo "repository=${repository}" >> "$GITHUB_OUTPUT"
+          echo "reference=${reference}" >> "$GITHUB_OUTPUT"
+          echo "safe_name=${safe_name}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push candidate without production tags
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./${{ matrix.meta.entries[0].directory }}/Dockerfile
+          push: true
+          tags: ${{ steps.candidate.outputs.reference }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
+          provenance: false
+
+      - name: Confirm all published platforms are in the candidate
+        id: manifest
+        env:
+          CANDIDATE: ${{ steps.candidate.outputs.repository }}@${{ steps.build.outputs.digest }}
+        run: |
+          manifest=$(docker buildx imagetools inspect --raw "$CANDIDATE")
+          actual=$(jq -r '[.manifests[].platform | .os + "/" + .architecture + (if .variant then "/" + .variant else "" end)] | sort | .[]' <<<"$manifest")
+          expected=$'linux/amd64\nlinux/arm/v7\nlinux/arm64\nlinux/ppc64le'
+          [[ "$actual" == "$expected" ]] || {
+            echo "Candidate platform set does not match the published platform set" >&2
+            diff -u <(printf '%s\n' "$expected") <(printf '%s\n' "$actual") || true
+            exit 1
+          }
+          platform_digests=$(jq -ce '
+            [.manifests[] | {
+              key: (.platform.os + "/" + .platform.architecture + (if .platform.variant then "/" + .platform.variant else "" end)),
+              value: .digest
+            }] | from_entries
+          ' <<<"$manifest")
+          echo "platform_digests=${platform_digests}" >> "$GITHUB_OUTPUT"
+
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
+        with:
+          version: v0.72.0
+
+      - name: Verify targeted findings are absent from the exact candidate digest
+        env:
+          CANDIDATE: ${{ steps.candidate.outputs.repository }}@${{ steps.build.outputs.digest }}
+          IMAGE_NAME: ${{ matrix.name }}
+          CANDIDATE_TAGS_JSON: ${{ toJson(matrix.meta.entries[0].tags) }}
+          TARGETS_B64: ${{ inputs.targeted_findings }}
+        run: |
+          python scripts/cve/verify_candidate.py \
+            --candidate "$CANDIDATE" \
+            --image-tag "$IMAGE_NAME" \
+            --candidate-tags-json "$CANDIDATE_TAGS_JSON" \
+            --targets-b64 "$TARGETS_B64"
+
+      - name: Record verified candidate metadata
+        env:
+          IMAGE_NAME: ${{ matrix.name }}
+          REPOSITORY: ${{ steps.candidate.outputs.repository }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+          ORIGINAL_TAGS: ${{ toJson(matrix.meta.entries[0].tags) }}
+          PLATFORM_DIGESTS: ${{ steps.manifest.outputs.platform_digests }}
+          SAFE_NAME: ${{ steps.candidate.outputs.safe_name }}
+        run: |
+          mkdir -p candidate-metadata
+          jq -n \
+            --arg name "$IMAGE_NAME" \
+            --arg repository "$REPOSITORY" \
+            --arg digest "$DIGEST" \
+            --argjson tags "$ORIGINAL_TAGS" \
+            --argjson platform_digests "$PLATFORM_DIGESTS" \
+            '{name: $name, repository: $repository, digest: $digest, tags: $tags, platform_digests: $platform_digests}' \
+            > "candidate-metadata/${SAFE_NAME}.json"
+
+      - name: Upload verified candidate metadata
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cve-candidate-${{ steps.candidate.outputs.safe_name }}
+          path: candidate-metadata/*.json
+          if-no-files-found: error
+
+  promote:
+    if: |
+      github.event_name == 'workflow_dispatch' &&
+      github.repository == 'valkey-io/valkey-container' &&
+      github.ref == 'refs/heads/mainline'
+    needs:
+      - generate-jobs
+      - build-verify
+    name: Promote verified CVE candidates
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Download verified candidate metadata
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: cve-candidate-*
+          path: candidate-metadata
+          merge-multiple: true
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Login to Docker Hub
+        if: needs.generate-jobs.outputs.publish_dockerhub == 'true'
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Configure AWS credentials via OIDC
+        if: needs.generate-jobs.outputs.publish_ecr == 'true'
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR Public Gallery
+        if: needs.generate-jobs.outputs.publish_ecr == 'true'
+        run: |
+          aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+
+      - name: Install registry promotion tool
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends skopeo
+
+      - name: Promote the verified digests to production tags
+        env:
+          GHCR_REPOSITORY: ghcr.io/${{ github.repository_owner }}/valkey
+          DOCKERHUB_REPOSITORY: ${{ needs.generate-jobs.outputs.publish_dockerhub == 'true' && format('docker.io/{0}/valkey', secrets.DOCKERHUB_ACCOUNT) || '' }}
+          ECR_REPOSITORY: ${{ needs.generate-jobs.outputs.publish_ecr == 'true' && format('public.ecr.aws/{0}/valkey', secrets.ECR_REGISTRY_ALIAS) || '' }}
+          CORRELATION_ID: ${{ inputs.correlation_id }}
+        run: |
+          python scripts/cve/promote_candidates.py \
+            --metadata-dir candidate-metadata \
+            --correlation-id "$CORRELATION_ID"
+
+      - name: Promotion summary
+        env:
+          CORRELATION_ID: ${{ inputs.correlation_id }}
+        run: |
+          {
+            echo "## CVE candidate promotion"
+            echo
+            echo "Correlation ID: \`$CORRELATION_ID\`"
+            echo
+            echo "Every targeted platform finding was absent from the immutable candidates before their exact digests were promoted."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .jq-template.awk
 .template-helper-functions.jq
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You should build and publish a new Docker Image after a new major, minor or patc
 
 ## CVE candidate rebuilds
 
-`ci.yml` has a separate mode for automated CVE rebuilds. A caller supplies affected
+`cve-rebuild.yml` is the dedicated workflow for automated CVE rebuilds. A caller supplies affected
 version lines, a unique `correlation_id`, and a base64 JSON list of targeted
 `(image, CVE, package, platform)` findings.
 

--- a/README.md
+++ b/README.md
@@ -20,3 +20,23 @@ You should build and publish a new Docker Image after a new major, minor or patc
 5. Verify all the tests pass on your fork and that your private Docker Hub repository has been updated.
 6. Publish a PR with these changes. For example: [#8](https://github.com/valkey-io/valkey-container/pull/8)
 7. Once the PR is merged, Sit back, relax and enjoy looking at your creation getting published to the official Docker Hub page.
+
+## CVE candidate rebuilds
+
+`ci.yml` has a separate mode for automated CVE rebuilds. A caller supplies affected
+version lines, a unique `correlation_id`, and a base64 JSON list of targeted
+`(image, CVE, package, platform)` findings.
+
+This mode never sends a newly built image directly to a production tag:
+
+1. The build and test matrices are restricted to the exact image variants named by the targets.
+2. Each variant is built for amd64, arm64, arm/v7, and ppc64le under a unique non-production GHCR tag.
+3. The workflow records the immutable multi-platform digest and each platform digest, then verifies the complete platform set.
+4. Trivy scans that exact digest on every targeted platform. Any original CVE/package tuple that remains fails the workflow.
+5. Only after every candidate passes are those same digests staged in GHCR, Docker Hub, and ECR and copied to production aliases with digest preservation enabled.
+6. Existing production digests are recorded before retagging. A promotion failure triggers rollback attempts and leaves the workflow failed even when rollback succeeds.
+
+The correlation ID is included in the workflow run name so callers can identify the
+exact run without timestamp polling. Candidate and staging tags are intentionally
+unique and retained as an audit trail; production consumers should continue using
+the documented release aliases.

--- a/scripts/cve/promote_candidates.py
+++ b/scripts/cve/promote_candidates.py
@@ -240,16 +240,18 @@ def promote(
 
 
 def configured_repositories() -> list[str]:
-    """Return enabled production repositories from explicit environment variables."""
-    return [
-        value
-        for value in (
-            os.environ.get("GHCR_REPOSITORY", ""),
-            os.environ.get("DOCKERHUB_REPOSITORY", ""),
-            os.environ.get("ECR_REPOSITORY", ""),
+    """Require and return every production registry destination."""
+    repositories = {
+        "GHCR_REPOSITORY": os.environ.get("GHCR_REPOSITORY", ""),
+        "DOCKERHUB_REPOSITORY": os.environ.get("DOCKERHUB_REPOSITORY", ""),
+        "ECR_REPOSITORY": os.environ.get("ECR_REPOSITORY", ""),
+    }
+    missing = [name for name, value in repositories.items() if not value]
+    if missing:
+        raise PromotionError(
+            "all production registries are required; missing " + ", ".join(missing)
         )
-        if value
-    ]
+    return list(repositories.values())
 
 
 def main() -> int:

--- a/scripts/cve/promote_candidates.py
+++ b/scripts/cve/promote_candidates.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Promote verified candidate digests to production tags with rollback."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+_CORRELATION_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_REQUIRED_PLATFORMS = frozenset({
+    "linux/amd64",
+    "linux/arm64",
+    "linux/arm/v7",
+    "linux/ppc64le",
+})
+
+
+class PromotionError(Exception):
+    """Raised when promotion cannot preserve the verified digest."""
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One verified multi-platform candidate and its production aliases."""
+
+    name: str
+    repository: str
+    digest: str
+    tags: tuple[str, ...]
+    platform_digests: tuple[tuple[str, str], ...] = ()
+
+    @property
+    def source(self) -> str:
+        return f"{self.repository}@{self.digest}"
+
+
+@dataclass(frozen=True)
+class Promotion:
+    """One production tag update derived from a candidate."""
+
+    source: str
+    destination: str
+    digest: str
+    staging: str
+
+
+def load_candidates(metadata_dir: Path) -> list[Candidate]:
+    """Load strict candidate metadata emitted by build jobs."""
+    paths = sorted(metadata_dir.glob("*.json"))
+    if not paths:
+        raise PromotionError(f"no candidate metadata found in {metadata_dir}")
+
+    candidates: list[Candidate] = []
+    for path in paths:
+        try:
+            payload = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError) as exc:
+            raise PromotionError(f"invalid candidate metadata {path}: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise PromotionError(f"candidate metadata {path} must be an object")
+        name = payload.get("name")
+        repository = payload.get("repository")
+        digest = payload.get("digest")
+        tags = payload.get("tags")
+        platform_digests = payload.get("platform_digests")
+        if not isinstance(name, str) or not name:
+            raise PromotionError(f"candidate metadata {path} has no name")
+        if not isinstance(repository, str) or "/" not in repository:
+            raise PromotionError(f"candidate metadata {path} has no repository")
+        if not isinstance(digest, str) or not _DIGEST_RE.fullmatch(digest):
+            raise PromotionError(f"candidate metadata {path} has an invalid digest")
+        if not isinstance(tags, list) or not tags or not all(isinstance(tag, str) for tag in tags):
+            raise PromotionError(f"candidate metadata {path} has no string tags")
+        if (
+            not isinstance(platform_digests, dict)
+            or set(platform_digests) != _REQUIRED_PLATFORMS
+            or not all(
+                isinstance(value, str) and _DIGEST_RE.fullmatch(value)
+                for value in platform_digests.values()
+            )
+        ):
+            raise PromotionError(
+                f"candidate metadata {path} must record exactly the published platform digests"
+            )
+        candidates.append(Candidate(
+            name,
+            repository,
+            digest,
+            tuple(tags),
+            tuple(sorted(platform_digests.items())),
+        ))
+    return candidates
+
+
+def _tag_suffix(tag: str) -> str:
+    prefix = "valkey-container:"
+    if not tag.startswith(prefix) or len(tag) == len(prefix):
+        raise PromotionError(f"unexpected generated tag {tag!r}")
+    return tag[len(prefix):]
+
+
+def build_promotions(
+    candidates: Iterable[Candidate],
+    *,
+    correlation_id: str,
+    repositories: Iterable[str],
+) -> list[Promotion]:
+    """Build a collision-free promotion plan for all registries and aliases."""
+    if not _CORRELATION_RE.fullmatch(correlation_id):
+        raise PromotionError("correlation ID contains unsafe characters")
+    repositories = tuple(repository for repository in repositories if repository)
+    if not repositories:
+        raise PromotionError("no production repositories are configured")
+
+    promotions: list[Promotion] = []
+    destinations: dict[str, str] = {}
+    for candidate in candidates:
+        safe_name = re.sub(r"[^A-Za-z0-9_.-]", "-", candidate.name)
+        for repository in repositories:
+            staging = f"{repository}:cve-staging-{correlation_id}-{safe_name}"
+            for generated_tag in candidate.tags:
+                destination = f"{repository}:{_tag_suffix(generated_tag)}"
+                prior = destinations.get(destination)
+                if prior is not None and prior != candidate.digest:
+                    raise PromotionError(
+                        f"production tag {destination} maps to multiple candidate digests"
+                    )
+                if prior == candidate.digest:
+                    continue
+                destinations[destination] = candidate.digest
+                promotions.append(
+                    Promotion(candidate.source, destination, candidate.digest, staging)
+                )
+    return promotions
+
+
+class Skopeo:
+    """Small fail-loud wrapper around skopeo."""
+
+    def __init__(self, authfile: Path) -> None:
+        self.authfile = authfile
+
+    def _run(self, args: list[str]) -> str:
+        if not args:
+            raise PromotionError("skopeo command is empty")
+        command = ["skopeo", args[0], "--authfile", str(self.authfile), *args[1:]]
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=1800,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise PromotionError(f"failed to run {' '.join(command)}: {exc}") from exc
+        if result.returncode != 0:
+            raise PromotionError(
+                f"{' '.join(command)} failed with exit {result.returncode}: "
+                f"{result.stderr[-2000:]}"
+            )
+        return result.stdout.strip()
+
+    def digest(self, reference: str) -> str:
+        output = self._run(["inspect", "--format", "{{.Digest}}", f"docker://{reference}"])
+        if not _DIGEST_RE.fullmatch(output):
+            raise PromotionError(f"registry returned invalid digest {output!r} for {reference}")
+        return output
+
+    def copy(self, source: str, destination: str) -> None:
+        self._run([
+            "copy",
+            "--all",
+            "--preserve-digests",
+            f"docker://{source}",
+            f"docker://{destination}",
+        ])
+
+
+def promote(
+    promotions: list[Promotion],
+    *,
+    skopeo: Skopeo,
+) -> None:
+    """Stage every digest, then update production tags with rollback on failure."""
+    if not promotions:
+        raise PromotionError("promotion plan is empty")
+
+    old_digests: dict[str, str] = {}
+    for promotion in promotions:
+        if skopeo.digest(promotion.source) != promotion.digest:
+            raise PromotionError(f"candidate digest changed for {promotion.source}")
+        old_digests[promotion.destination] = skopeo.digest(promotion.destination)
+
+    staged: set[tuple[str, str]] = set()
+    for promotion in promotions:
+        key = (promotion.staging, promotion.digest)
+        if key in staged:
+            continue
+        skopeo.copy(promotion.source, promotion.staging)
+        if skopeo.digest(promotion.staging) != promotion.digest:
+            raise PromotionError(f"staging digest mismatch for {promotion.staging}")
+        staged.add(key)
+
+    attempted: list[Promotion] = []
+    try:
+        for promotion in promotions:
+            staging_repository = promotion.staging.rsplit(":", 1)[0]
+            # A registry may update the tag and still report a failed copy. Add
+            # the destination before the operation so it participates in
+            # rollback even when the failing copy was only partially applied.
+            attempted.append(promotion)
+            skopeo.copy(f"{staging_repository}@{promotion.digest}", promotion.destination)
+            if skopeo.digest(promotion.destination) != promotion.digest:
+                raise PromotionError(f"production digest mismatch for {promotion.destination}")
+            print(f"Promoted {promotion.destination} -> {promotion.digest}")
+    except PromotionError as exc:
+        rollback_errors: list[str] = []
+        for promotion in reversed(attempted):
+            old_digest = old_digests[promotion.destination]
+            repository = promotion.destination.rsplit(":", 1)[0]
+            try:
+                skopeo.copy(f"{repository}@{old_digest}", promotion.destination)
+                if skopeo.digest(promotion.destination) != old_digest:
+                    raise PromotionError("rollback digest verification failed")
+            except PromotionError as rollback_exc:
+                rollback_errors.append(f"{promotion.destination}: {rollback_exc}")
+        suffix = ""
+        if rollback_errors:
+            suffix = "; rollback failures: " + "; ".join(rollback_errors)
+        raise PromotionError(f"promotion failed and rollback was attempted: {exc}{suffix}") from exc
+
+
+def configured_repositories() -> list[str]:
+    """Return enabled production repositories from explicit environment variables."""
+    return [
+        value
+        for value in (
+            os.environ.get("GHCR_REPOSITORY", ""),
+            os.environ.get("DOCKERHUB_REPOSITORY", ""),
+            os.environ.get("ECR_REPOSITORY", ""),
+        )
+        if value
+    ]
+
+
+def main() -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--metadata-dir", type=Path, required=True)
+    parser.add_argument("--correlation-id", required=True)
+    parser.add_argument(
+        "--authfile",
+        type=Path,
+        default=Path.home() / ".docker" / "config.json",
+    )
+    args = parser.parse_args()
+
+    try:
+        candidates = load_candidates(args.metadata_dir)
+        plan = build_promotions(
+            candidates,
+            correlation_id=args.correlation_id,
+            repositories=configured_repositories(),
+        )
+        promote(plan, skopeo=Skopeo(args.authfile))
+    except PromotionError as exc:
+        print(f"candidate promotion failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cve/verify_candidate.py
+++ b/scripts/cve/verify_candidate.py
@@ -158,24 +158,36 @@ def run_trivy(candidate: str, platform: str, *, executable: str = "trivy") -> di
     return payload
 
 
-def target_matches_candidate(target_tag: str, candidate_name: str) -> bool:
-    """Match a published version-line tag to its concrete build matrix entry."""
-    if target_tag == candidate_name:
-        return True
-    match = re.fullmatch(r"(?P<line>\d+\.\d+)(?P<alpine>-alpine)?", target_tag)
-    if match is None:
-        return False
-    suffix = "-alpine" if match.group("alpine") else ""
-    return re.fullmatch(
-        rf"{re.escape(match.group('line'))}\.\d+{re.escape(suffix)}",
-        candidate_name,
-    ) is not None
+def decode_candidate_tags(raw: str) -> list[str]:
+    """Parse the exact aliases generated for one build matrix entry."""
+    try:
+        tags = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise VerificationError("candidate tags are not valid JSON") from exc
+    if (
+        not isinstance(tags, list)
+        or not tags
+        or not all(
+            isinstance(tag, str) and tag.startswith("valkey-container:")
+            for tag in tags
+        )
+    ):
+        raise VerificationError(
+            "candidate tags must be a non-empty list of valkey-container aliases"
+        )
+    return tags
+
+
+def target_matches_candidate(target_tag: str, candidate_tags: list[str]) -> bool:
+    """Match a scan target against the aliases generated for the candidate."""
+    return f"valkey-container:{target_tag}" in candidate_tags
 
 
 def verify_candidate(
     *,
     candidate: str,
     image_tag: str,
+    candidate_tags: list[str],
     targets: list[Target],
     trivy_executable: str = "trivy",
 ) -> None:
@@ -186,7 +198,7 @@ def verify_candidate(
     selected = [
         target
         for target in targets
-        if target_matches_candidate(target.image_tag, image_tag)
+        if target_matches_candidate(target.image_tag, candidate_tags)
     ]
     if not selected:
         raise VerificationError(f"no targeted findings were supplied for image {image_tag!r}")
@@ -226,15 +238,18 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--candidate", required=True)
     parser.add_argument("--image-tag", required=True)
+    parser.add_argument("--candidate-tags-json", required=True)
     parser.add_argument("--targets-b64", required=True)
     parser.add_argument("--trivy", default="trivy")
     args = parser.parse_args()
 
     try:
         targets = decode_targets(args.targets_b64)
+        candidate_tags = decode_candidate_tags(args.candidate_tags_json)
         verify_candidate(
             candidate=args.candidate,
             image_tag=args.image_tag,
+            candidate_tags=candidate_tags,
             targets=targets,
             trivy_executable=args.trivy,
         )

--- a/scripts/cve/verify_candidate.py
+++ b/scripts/cve/verify_candidate.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Verify that targeted OS-package CVEs are absent from a candidate image."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import json
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any
+
+_DIGEST_REF_RE = re.compile(r"^\S+@sha256:[0-9a-f]{64}$")
+_REQUIRED_TARGET_FIELDS = (
+    "image",
+    "package",
+    "cve_id",
+    "platform",
+)
+
+
+class VerificationError(Exception):
+    """Raised when input or scanner output cannot be verified safely."""
+
+
+@dataclass(frozen=True)
+class Target:
+    """A platform-specific vulnerability that a candidate must remove."""
+
+    image: str
+    package: str
+    cve_id: str
+    platform: str
+
+    @property
+    def image_tag(self) -> str:
+        """Return the tag portion used by the container build matrix."""
+        return self.image.rsplit(":", 1)[-1]
+
+
+def decode_targets(encoded: str) -> list[Target]:
+    """Decode and strictly validate the base64-encoded target list."""
+    try:
+        raw = base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise VerificationError("targeted_findings is not valid base64") from exc
+
+    try:
+        payload = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise VerificationError("targeted_findings does not contain valid UTF-8 JSON") from exc
+
+    if not isinstance(payload, list) or not payload:
+        raise VerificationError("targeted_findings must be a non-empty JSON list")
+
+    targets: list[Target] = []
+    for index, value in enumerate(payload):
+        if not isinstance(value, dict):
+            raise VerificationError(f"targeted_findings[{index}] must be an object")
+        for field in _REQUIRED_TARGET_FIELDS:
+            field_value = value.get(field)
+            if not isinstance(field_value, str) or not field_value.strip():
+                raise VerificationError(
+                    f"targeted_findings[{index}].{field} must be a non-empty string"
+                )
+        target = Target(**{field: value[field] for field in _REQUIRED_TARGET_FIELDS})
+        if not target.platform.startswith("linux/"):
+            raise VerificationError(
+                f"targeted_findings[{index}].platform must start with 'linux/'"
+            )
+        targets.append(target)
+    return targets
+
+
+def parse_trivy_findings(payload: Any, *, context: str) -> set[tuple[str, str]]:
+    """Return vulnerable ``(CVE, package)`` pairs from strict Trivy JSON."""
+    if not isinstance(payload, dict):
+        raise VerificationError(f"{context}: Trivy output must be a JSON object")
+    schema_version = payload.get("SchemaVersion")
+    if isinstance(schema_version, bool) or not isinstance(schema_version, int):
+        raise VerificationError(f"{context}: Trivy output has no integer SchemaVersion")
+
+    results = payload.get("Results", [])
+    if not isinstance(results, list):
+        raise VerificationError(f"{context}: Trivy Results must be a list")
+
+    findings: set[tuple[str, str]] = set()
+    for result_index, result in enumerate(results):
+        if not isinstance(result, dict):
+            raise VerificationError(f"{context}: Results[{result_index}] must be an object")
+        vulnerabilities = result.get("Vulnerabilities")
+        if vulnerabilities is None:
+            continue
+        if not isinstance(vulnerabilities, list):
+            raise VerificationError(
+                f"{context}: Results[{result_index}].Vulnerabilities must be a list"
+            )
+        for vulnerability_index, vulnerability in enumerate(vulnerabilities):
+            if not isinstance(vulnerability, dict):
+                raise VerificationError(
+                    f"{context}: vulnerability {vulnerability_index} must be an object"
+                )
+            cve_id = vulnerability.get("VulnerabilityID")
+            package = vulnerability.get("PkgName")
+            if not isinstance(cve_id, str) or not cve_id:
+                raise VerificationError(f"{context}: vulnerability has no string VulnerabilityID")
+            if not isinstance(package, str) or not package:
+                raise VerificationError(f"{context}: vulnerability has no string PkgName")
+            findings.add((cve_id, package))
+    return findings
+
+
+def run_trivy(candidate: str, platform: str, *, executable: str = "trivy") -> dict[str, Any]:
+    """Scan one immutable candidate platform and return parsed Trivy JSON."""
+    command = [
+        executable,
+        "image",
+        "--format",
+        "json",
+        "--quiet",
+        "--scanners",
+        "vuln",
+        "--pkg-types",
+        "os",
+        "--platform",
+        platform,
+        candidate,
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=600,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise VerificationError(f"Trivy failed for {candidate} ({platform}): {exc}") from exc
+    if result.returncode != 0:
+        raise VerificationError(
+            f"Trivy failed for {candidate} ({platform}), exit {result.returncode}: "
+            f"{result.stderr[-1000:]}"
+        )
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise VerificationError(
+            f"Trivy returned invalid JSON for {candidate} ({platform})"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise VerificationError(
+            f"Trivy returned a non-object document for {candidate} ({platform})"
+        )
+    return payload
+
+
+def target_matches_candidate(target_tag: str, candidate_name: str) -> bool:
+    """Match a published version-line tag to its concrete build matrix entry."""
+    if target_tag == candidate_name:
+        return True
+    match = re.fullmatch(r"(?P<line>\d+\.\d+)(?P<alpine>-alpine)?", target_tag)
+    if match is None:
+        return False
+    suffix = "-alpine" if match.group("alpine") else ""
+    return re.fullmatch(
+        rf"{re.escape(match.group('line'))}\.\d+{re.escape(suffix)}",
+        candidate_name,
+    ) is not None
+
+
+def verify_candidate(
+    *,
+    candidate: str,
+    image_tag: str,
+    targets: list[Target],
+    trivy_executable: str = "trivy",
+) -> None:
+    """Fail unless every target for ``image_tag`` is absent from the candidate."""
+    if not _DIGEST_REF_RE.fullmatch(candidate):
+        raise VerificationError("candidate must be an immutable @sha256 digest reference")
+
+    selected = [
+        target
+        for target in targets
+        if target_matches_candidate(target.image_tag, image_tag)
+    ]
+    if not selected:
+        raise VerificationError(f"no targeted findings were supplied for image {image_tag!r}")
+
+    by_platform: dict[str, list[Target]] = defaultdict(list)
+    for target in selected:
+        by_platform[target.platform].append(target)
+
+    unresolved: list[Target] = []
+    for platform, platform_targets in sorted(by_platform.items()):
+        payload = run_trivy(candidate, platform, executable=trivy_executable)
+        findings = parse_trivy_findings(
+            payload,
+            context=f"{candidate} ({platform})",
+        )
+        unresolved.extend(
+            target
+            for target in platform_targets
+            if (target.cve_id, target.package) in findings
+        )
+
+    if unresolved:
+        details = ", ".join(
+            f"{target.cve_id}/{target.package}/{target.platform}"
+            for target in unresolved
+        )
+        raise VerificationError(f"candidate still contains targeted findings: {details}")
+
+    print(
+        f"Verified {candidate}: {len(selected)} targeted finding(s) absent "
+        f"across {len(by_platform)} platform(s)."
+    )
+
+
+def main() -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--candidate", required=True)
+    parser.add_argument("--image-tag", required=True)
+    parser.add_argument("--targets-b64", required=True)
+    parser.add_argument("--trivy", default="trivy")
+    args = parser.parse_args()
+
+    try:
+        targets = decode_targets(args.targets_b64)
+        verify_candidate(
+            candidate=args.candidate,
+            image_tag=args.image_tag,
+            targets=targets,
+            trivy_executable=args.trivy,
+        )
+    except VerificationError as exc:
+        print(f"candidate verification failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cve_candidate.py
+++ b/tests/test_cve_candidate.py
@@ -12,6 +12,7 @@ from scripts.cve.promote_candidates import (
     Promotion,
     PromotionError,
     build_promotions,
+    configured_repositories,
     load_candidates,
     promote,
 )
@@ -153,6 +154,26 @@ class VerifyCandidateTests(unittest.TestCase):
 
 
 class PromoteCandidateTests(unittest.TestCase):
+    def test_configured_repositories_requires_all_production_registries(self) -> None:
+        with patch.dict("os.environ", {
+            "GHCR_REPOSITORY": "ghcr.io/valkey-io/valkey",
+            "DOCKERHUB_REPOSITORY": "docker.io/valkey/valkey",
+        }, clear=True):
+            with self.assertRaisesRegex(PromotionError, "missing ECR_REPOSITORY"):
+                configured_repositories()
+
+        expected = [
+            "ghcr.io/valkey-io/valkey",
+            "docker.io/valkey/valkey",
+            "public.ecr.aws/valkey/valkey",
+        ]
+        with patch.dict("os.environ", {
+            "GHCR_REPOSITORY": expected[0],
+            "DOCKERHUB_REPOSITORY": expected[1],
+            "ECR_REPOSITORY": expected[2],
+        }, clear=True):
+            self.assertEqual(configured_repositories(), expected)
+
     def test_load_candidates_and_build_registry_plan(self) -> None:
         digest = "sha256:" + "a" * 64
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_cve_candidate.py
+++ b/tests/test_cve_candidate.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import base64
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts.cve.promote_candidates import (
+    Candidate,
+    Promotion,
+    PromotionError,
+    build_promotions,
+    load_candidates,
+    promote,
+)
+from scripts.cve.verify_candidate import (
+    Target,
+    VerificationError,
+    decode_targets,
+    parse_trivy_findings,
+    target_matches_candidate,
+    verify_candidate,
+)
+
+
+def _encoded_targets(values: list[dict[str, str]]) -> str:
+    return base64.b64encode(json.dumps(values).encode()).decode()
+
+
+def _target(**overrides: str) -> dict[str, str]:
+    value = {
+        "image": "valkey/valkey:9.0",
+        "package": "libssl3t64",
+        "cve_id": "CVE-2026-0001",
+        "platform": "linux/amd64",
+    }
+    value.update(overrides)
+    return value
+
+
+def _platform_digests() -> dict[str, str]:
+    return {
+        "linux/amd64": "sha256:" + "1" * 64,
+        "linux/arm64": "sha256:" + "2" * 64,
+        "linux/arm/v7": "sha256:" + "3" * 64,
+        "linux/ppc64le": "sha256:" + "4" * 64,
+    }
+
+
+class VerifyCandidateTests(unittest.TestCase):
+    def test_version_line_target_matches_concrete_matrix_name(self) -> None:
+        self.assertTrue(target_matches_candidate("9.0", "9.0.5"))
+        self.assertTrue(target_matches_candidate("9.0-alpine", "9.0.5-alpine"))
+        self.assertTrue(target_matches_candidate("unstable", "unstable"))
+        self.assertFalse(target_matches_candidate("9.0", "9.0.5-alpine"))
+        self.assertFalse(target_matches_candidate("9.0-alpine", "9.0.5"))
+        self.assertFalse(target_matches_candidate("9.0", "9.1.1"))
+
+    def test_decode_targets_round_trips_strict_contract(self) -> None:
+        self.assertEqual(
+            decode_targets(_encoded_targets([_target()])),
+            [Target(
+                image="valkey/valkey:9.0",
+                package="libssl3t64",
+                cve_id="CVE-2026-0001",
+                platform="linux/amd64",
+            )],
+        )
+
+    def test_decode_targets_rejects_malformed_payloads(self) -> None:
+        values = [
+            "not base64",
+            base64.b64encode(b"not json").decode(),
+            _encoded_targets([]),
+            _encoded_targets([{"image": "valkey/valkey:9.0"}]),
+        ]
+        for encoded in values:
+            with self.subTest(encoded=encoded):
+                with self.assertRaises(VerificationError):
+                    decode_targets(encoded)
+
+    def test_parse_trivy_findings_is_strict(self) -> None:
+        payload = {
+            "SchemaVersion": 2,
+            "Results": [{
+                "Vulnerabilities": [{
+                    "VulnerabilityID": "CVE-2026-0001",
+                    "PkgName": "libssl3t64",
+                }],
+            }],
+        }
+        self.assertEqual(
+            parse_trivy_findings(payload, context="test"),
+            {("CVE-2026-0001", "libssl3t64")},
+        )
+
+    def test_verify_candidate_accepts_absent_target(self) -> None:
+        target = Target(**_target())
+        with patch(
+            "scripts.cve.verify_candidate.run_trivy",
+            return_value={"SchemaVersion": 2, "Results": []},
+        ):
+            verify_candidate(
+                candidate="ghcr.io/valkey-io/valkey@sha256:" + "a" * 64,
+                image_tag="9.0.5",
+                targets=[target],
+            )
+
+    def test_verify_candidate_rejects_target_still_present(self) -> None:
+        target = Target(**_target())
+        payload = {
+            "SchemaVersion": 2,
+            "Results": [{
+                "Vulnerabilities": [{
+                    "VulnerabilityID": target.cve_id,
+                    "PkgName": target.package,
+                }],
+            }],
+        }
+        with patch("scripts.cve.verify_candidate.run_trivy", return_value=payload):
+            with self.assertRaisesRegex(VerificationError, "still contains"):
+                verify_candidate(
+                    candidate="ghcr.io/valkey-io/valkey@sha256:" + "a" * 64,
+                    image_tag="9.0.5",
+                    targets=[target],
+                )
+
+    def test_verify_candidate_requires_target_for_matrix_image(self) -> None:
+        with self.assertRaisesRegex(VerificationError, "no targeted findings"):
+            verify_candidate(
+                candidate="ghcr.io/valkey-io/valkey@sha256:" + "a" * 64,
+                image_tag="8.1",
+                targets=[Target(**_target())],
+            )
+
+
+class PromoteCandidateTests(unittest.TestCase):
+    def test_load_candidates_and_build_registry_plan(self) -> None:
+        digest = "sha256:" + "a" * 64
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory)
+            (path / "9.0.json").write_text(json.dumps({
+                "name": "9.0",
+                "repository": "ghcr.io/valkey-io/valkey",
+                "digest": digest,
+                "tags": ["valkey-container:9.0.5", "valkey-container:9.0"],
+                "platform_digests": _platform_digests(),
+            }))
+            candidates = load_candidates(path)
+        plan = build_promotions(
+            candidates,
+            correlation_id="123-1",
+            repositories=["ghcr.io/valkey-io/valkey", "docker.io/valkey/valkey"],
+        )
+        self.assertEqual(
+            {item.destination for item in plan},
+            {
+                "ghcr.io/valkey-io/valkey:9.0.5",
+                "ghcr.io/valkey-io/valkey:9.0",
+                "docker.io/valkey/valkey:9.0.5",
+                "docker.io/valkey/valkey:9.0",
+            },
+        )
+        self.assertTrue(all(item.digest == digest for item in plan))
+
+    def test_build_promotions_rejects_unsafe_correlation(self) -> None:
+        candidate = Candidate(
+            "9.0",
+            "ghcr.io/valkey-io/valkey",
+            "sha256:" + "a" * 64,
+            ("valkey-container:9.0",),
+        )
+        with self.assertRaisesRegex(PromotionError, "unsafe"):
+            build_promotions(
+                [candidate],
+                correlation_id="bad value",
+                repositories=["ghcr.io/valkey-io/valkey"],
+            )
+
+    def test_build_promotions_rejects_destination_collision(self) -> None:
+        candidates = [
+            Candidate(
+                "9.0",
+                "ghcr.io/valkey-io/valkey",
+                "sha256:" + "a" * 64,
+                ("valkey-container:latest",),
+            ),
+            Candidate(
+                "9.1",
+                "ghcr.io/valkey-io/valkey",
+                "sha256:" + "b" * 64,
+                ("valkey-container:latest",),
+            ),
+        ]
+        with self.assertRaisesRegex(PromotionError, "multiple candidate digests"):
+            build_promotions(
+                candidates,
+                correlation_id="123-1",
+                repositories=["ghcr.io/valkey-io/valkey"],
+            )
+
+    def test_promote_stages_then_updates_exact_digest(self) -> None:
+        digest = "sha256:" + "a" * 64
+        old_digest = "sha256:" + "b" * 64
+        plan = [Promotion(
+            source=f"ghcr.io/valkey-io/valkey@{digest}",
+            destination="docker.io/valkey/valkey:9.0",
+            digest=digest,
+            staging="docker.io/valkey/valkey:cve-staging-1-9.0",
+        )]
+        skopeo = _FakeSkopeo({
+            plan[0].source: digest,
+            plan[0].destination: old_digest,
+        })
+
+        promote(plan, skopeo=skopeo)  # type: ignore[arg-type]
+
+        self.assertEqual(skopeo.digests[plan[0].destination], digest)
+        self.assertEqual(skopeo.digests[plan[0].staging], digest)
+
+    def test_promote_rolls_back_prior_tag_when_later_tag_fails(self) -> None:
+        digest = "sha256:" + "a" * 64
+        old_one = "sha256:" + "b" * 64
+        old_two = "sha256:" + "c" * 64
+        source = f"ghcr.io/valkey-io/valkey@{digest}"
+        staging = "docker.io/valkey/valkey:cve-staging-1-9.0"
+        plan = [
+            Promotion(source, "docker.io/valkey/valkey:9.0", digest, staging),
+            Promotion(source, "docker.io/valkey/valkey:9", digest, staging),
+        ]
+        skopeo = _FakeSkopeo({
+            source: digest,
+            plan[0].destination: old_one,
+            plan[1].destination: old_two,
+        }, fail_once=plan[1].destination)
+
+        with self.assertRaisesRegex(PromotionError, "rollback was attempted"):
+            promote(plan, skopeo=skopeo)  # type: ignore[arg-type]
+
+        self.assertEqual(skopeo.digests[plan[0].destination], old_one)
+        self.assertEqual(skopeo.digests[plan[1].destination], old_two)
+
+
+class _FakeSkopeo:
+    def __init__(self, digests: dict[str, str], fail_once: str = "") -> None:
+        self.digests = dict(digests)
+        self.fail_once = fail_once
+
+    def digest(self, reference: str) -> str:
+        if reference in self.digests:
+            return self.digests[reference]
+        if "@sha256:" in reference:
+            return "sha256:" + reference.rsplit("@sha256:", 1)[1]
+        raise PromotionError(f"missing fake reference {reference}")
+
+    def copy(self, source: str, destination: str) -> None:
+        if destination == self.fail_once:
+            self.fail_once = ""
+            raise PromotionError("injected copy failure")
+        self.digests[destination] = self.digest(source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cve_candidate.py
+++ b/tests/test_cve_candidate.py
@@ -18,6 +18,7 @@ from scripts.cve.promote_candidates import (
 from scripts.cve.verify_candidate import (
     Target,
     VerificationError,
+    decode_candidate_tags,
     decode_targets,
     parse_trivy_findings,
     target_matches_candidate,
@@ -50,13 +51,25 @@ def _platform_digests() -> dict[str, str]:
 
 
 class VerifyCandidateTests(unittest.TestCase):
-    def test_version_line_target_matches_concrete_matrix_name(self) -> None:
-        self.assertTrue(target_matches_candidate("9.0", "9.0.5"))
-        self.assertTrue(target_matches_candidate("9.0-alpine", "9.0.5-alpine"))
-        self.assertTrue(target_matches_candidate("unstable", "unstable"))
-        self.assertFalse(target_matches_candidate("9.0", "9.0.5-alpine"))
-        self.assertFalse(target_matches_candidate("9.0-alpine", "9.0.5"))
-        self.assertFalse(target_matches_candidate("9.0", "9.1.1"))
+    def test_target_matches_generated_aliases_including_release_candidates(self) -> None:
+        rc_tags = ["valkey-container:9.1.0-rc1", "valkey-container:9.1"]
+        rc_alpine_tags = [
+            "valkey-container:9.1.0-rc1-alpine",
+            "valkey-container:9.1-alpine",
+        ]
+        self.assertTrue(target_matches_candidate("9.1", rc_tags))
+        self.assertTrue(target_matches_candidate("9.1-alpine", rc_alpine_tags))
+        self.assertFalse(target_matches_candidate("9.1", rc_alpine_tags))
+        self.assertFalse(target_matches_candidate("9.1-alpine", rc_tags))
+
+    def test_decode_candidate_tags_is_strict(self) -> None:
+        self.assertEqual(
+            decode_candidate_tags('["valkey-container:9.1.0-rc1", "valkey-container:9.1"]'),
+            ["valkey-container:9.1.0-rc1", "valkey-container:9.1"],
+        )
+        for raw in ("not json", "[]", '["other:9.1"]'):
+            with self.subTest(raw=raw), self.assertRaises(VerificationError):
+                decode_candidate_tags(raw)
 
     def test_decode_targets_round_trips_strict_contract(self) -> None:
         self.assertEqual(
@@ -105,6 +118,7 @@ class VerifyCandidateTests(unittest.TestCase):
             verify_candidate(
                 candidate="ghcr.io/valkey-io/valkey@sha256:" + "a" * 64,
                 image_tag="9.0.5",
+                candidate_tags=["valkey-container:9.0.5", "valkey-container:9.0"],
                 targets=[target],
             )
 
@@ -124,6 +138,7 @@ class VerifyCandidateTests(unittest.TestCase):
                 verify_candidate(
                     candidate="ghcr.io/valkey-io/valkey@sha256:" + "a" * 64,
                     image_tag="9.0.5",
+                    candidate_tags=["valkey-container:9.0.5", "valkey-container:9.0"],
                     targets=[target],
                 )
 
@@ -132,6 +147,7 @@ class VerifyCandidateTests(unittest.TestCase):
             verify_candidate(
                 candidate="ghcr.io/valkey-io/valkey@sha256:" + "a" * 64,
                 image_tag="8.1",
+                candidate_tags=["valkey-container:8.1"],
                 targets=[Target(**_target())],
             )
 


### PR DESCRIPTION
#### Summary

Add a dedicated CVE rebuild mode that verifies the exact container artifact before updating production tags.

The workflow now:

- accepts affected version lines, a unique correlation ID, and targeted `(image, CVE, package, platform)` findings
- maps every targeted version-line/variant to exactly one concrete build entry
- builds all published platforms under a unique non-production GHCR reference
- records the immutable multi-platform digest and individual platform digests
- scans the exact candidate digest on every targeted platform
- fails if any originally targeted CVE/package finding remains
- promotes those same verified digests to GHCR, Docker Hub, and ECR without rebuilding
- includes the correlation ID in `run-name` for deterministic downstream-run lookup

#### Promotion safety

Production promotion starts only after every candidate build and scan passes.

Before updating production aliases, the workflow:

1. verifies the candidate digest
2. stages the digest in every enabled registry using digest-preserving copies
3. records the previous production digests
4. updates and verifies each production alias
5. attempts rollback to every recorded digest if promotion fails

Candidate and staging references are retained as an audit trail.

Cross-registry tag updates cannot be globally atomic, so rollback is best-effort. Any build, verification, staging, promotion, or rollback error fails the workflow.

#### Why

The previous design attempted to predict whether rebuilding would fix a vulnerability by modeling Dockerfile, package-manager, repository, and multi-stage build behavior.

The stronger and simpler property is:

> Verify the exact artifact being promoted, not a model of how rebuilding might change it.

This may occasionally spend build compute on a candidate that is rejected, but it prevents an incorrect predictor from publishing or suppressing a rebuild.