### PR TITLE
Centralize the container image build action

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -1,0 +1,44 @@
+name: Build Valkey container image
+description: Canonical Buildx setup and image build used by Valkey container workflows.
+
+inputs:
+  context:
+    description: Path build context.
+    required: true
+  dockerfile:
+    description: Dockerfile path passed to Buildx.
+    required: true
+  platforms:
+    description: Comma-separated target platforms.
+    required: true
+  tags:
+    description: Comma-separated image tags.
+    required: true
+  push:
+    description: Push the build result to configured registries.
+    required: false
+    default: "false"
+  load:
+    description: Load a single-platform build into the local Docker daemon.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+    - name: Build image
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+      with:
+        context: ${{ inputs.context }}
+        file: ${{ inputs.dockerfile }}
+        platforms: ${{ inputs.platforms }}
+        tags: ${{ inputs.tags }}
+        provenance: false
+        push: ${{ inputs.push }}
+        load: ${{ inputs.load }}

--- a/.github/actions/build-image/smoke.Dockerfile
+++ b/.github/actions/build-image/smoke.Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+LABEL org.valkey.smoke="build-image"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: GitHub CI
+run-name: ${{ inputs.correlation_id != '' && format('CVE rebuild {0}', inputs.correlation_id) || github.event.pull_request.title || github.event.head_commit.message || github.workflow }}
 
 on:
   pull_request:
@@ -10,6 +11,10 @@ on:
       version:
         description: 'Versions to build and push, space-separated (ex: "9.0.2" or "9.0.2 8.1.5" or unstable)'
         required: true
+        type: string
+      correlation_id:
+        description: 'Optional caller-provided identifier used to locate this workflow run'
+        required: false
         type: string
 
 env:
@@ -124,6 +129,10 @@ jobs:
       contents: read
       packages: write
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
         # Tags are created by generate.sh in the format `valkey-container:<tag>`
         # For Docker Hub this step modifies the tags to `account/valkey:<tag>` to be provided to build-push github action.
         # For GitHub Container Registry this step modifies the tags to `ghcr.io/<repo-owner>/valkey:<tag>` to be provided to build-push github action.
@@ -149,12 +158,6 @@ jobs:
           fi
 
           echo "tags=$all_tags" >> $GITHUB_OUTPUT
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Login to Docker Hub
         if: env.PUBLISH_DOCKERHUB == 'true'
@@ -185,13 +188,13 @@ jobs:
           aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
 
       - name: Build and push
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        uses: ./.github/actions/build-image
         with:
-          file: ./${{ matrix.meta.entries[0].directory }}/Dockerfile
-          push: ${{ env.PUBLISH_DOCKERHUB == 'true' || env.PUBLISH_GHCR == 'true' || env.PUBLISH_ECR == 'true' }}
-          tags: ${{ steps.modify_tags.outputs.tags }}
+          context: "{{defaultContext}}"
+          dockerfile: ./${{ matrix.meta.entries[0].directory }}/Dockerfile
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
-          provenance: false
+          tags: ${{ steps.modify_tags.outputs.tags }}
+          push: ${{ env.PUBLISH_DOCKERHUB == 'true' || env.PUBLISH_GHCR == 'true' || env.PUBLISH_ECR == 'true' }}
           load: false
 
   update-dockerhub-ecr-description-file:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,31 @@ jobs:
       - name: '"docker images"'
         run: ${{ matrix.runs.images }}
 
+  build_action_smoke:
+    if: github.event_name == 'pull_request'
+    name: Shared build action smoke test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Build and load smoke image
+        uses: ./.github/actions/build-image
+        with:
+          context: .
+          dockerfile: ./.github/actions/build-image/smoke.Dockerfile
+          platforms: linux/amd64
+          tags: valkey-build-action-smoke:${{ github.sha }}
+          push: false
+          load: true
+      - name: Inspect smoke image
+        run: |
+          test "$(docker image inspect \
+            valkey-build-action-smoke:${{ github.sha }} \
+            --format '{{ index .Config.Labels "org.valkey.smoke" }}')" = "build-image"
+
   build_and_push:
     if: |
       ((github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&


### PR DESCRIPTION
This centralizes the build actions and makes it reusable for other repo like CVE scan verification for valkey-ci-agent