### PR TITLE
Add tini as PID 1 to reap orphaned processes

### DIFF
--- a/.test/config.sh
+++ b/.test/config.sh
@@ -9,5 +9,6 @@ imageTests+=(
 		valkey-readonly-data
 		valkey-user-flag
 		valkey-sbom
+		valkey-tini
 	'
 )

--- a/.test/tests/valkey-tini/run.sh
+++ b/.test/tests/valkey-tini/run.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+image="$1"
+
+network="valkey-network-$RANDOM-$RANDOM"
+docker network create "$network" >/dev/null
+
+cname="valkey-container-$RANDOM-$RANDOM"
+cid="$(docker run -d --name "$cname" --network "$network" "$image")"
+
+trap "docker rm -vf '$cid' >/dev/null; docker network rm '$network' >/dev/null" EXIT
+
+valkey-cli() {
+  docker run --rm -i \
+    --network "$network" \
+    --entrypoint valkey-cli \
+    "$image" \
+    -h "$cname" \
+    "$@"
+}
+
+. "$dir/../../retry.sh" --tries 20 '[ "$(valkey-cli ping)" = "PONG" ]'
+
+# tini must be PID 1 so it can reap orphaned processes (e.g. left behind by exec-based healthchecks/probes)
+[ "$(docker exec "$cid" cat /proc/1/comm)" = 'tini' ]
+
+# Simulate an orphaned process: spawn a detached shell whose child outlives it,
+# so the child gets reparented to PID 1. Without an init reaping zombies, it
+# would remain as a defunct process indefinitely.
+docker exec -d "$cid" sh -c 'sleep 2 & exit 0'
+sleep 3
+[ "$(docker exec "$cid" sh -c "cat /proc/*/stat 2>/dev/null | awk '\$3 == \"Z\"' | wc -l")" = '0' ]

--- a/7.2/alpine/Dockerfile
+++ b/7.2/alpine/Dockerfile
@@ -109,6 +109,8 @@ RUN set -eux; \
 		setpriv \
 		openssl \
 		libgcc \
+		# add tini to act as PID 1 and reap orphaned/zombie processes
+		tini \
 	;
 
 # Install valkey built earlier
@@ -124,7 +126,7 @@ RUN mkdir /data && \
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["valkey-server"]

--- a/7.2/debian/Dockerfile
+++ b/7.2/debian/Dockerfile
@@ -92,6 +92,8 @@ RUN set -eux; \
 # add tzdata explicitly for https://github.com/docker-library/redis/issues/138 (see also https://bugs.debian.org/837060 and related)
 		tzdata \
 		libssl3t64 \
+		# add tini to act as PID 1 and reap orphaned/zombie processes
+		tini \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -108,7 +110,7 @@ RUN mkdir /data && \
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["valkey-server"]

--- a/8.0/alpine/Dockerfile
+++ b/8.0/alpine/Dockerfile
@@ -109,6 +109,8 @@ RUN set -eux; \
 		setpriv \
 		openssl \
 		libgcc \
+		# add tini to act as PID 1 and reap orphaned/zombie processes
+		tini \
 	;
 
 # Install valkey built earlier
@@ -124,7 +126,7 @@ RUN mkdir /data && \
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["valkey-server"]

--- a/8.0/debian/Dockerfile
+++ b/8.0/debian/Dockerfile
@@ -92,6 +92,8 @@ RUN set -eux; \
 # add tzdata explicitly for https://github.com/docker-library/redis/issues/138 (see also https://bugs.debian.org/837060 and related)
 		tzdata \
 		libssl3t64 \
+		# add tini to act as PID 1 and reap orphaned/zombie processes
+		tini \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -108,7 +110,7 @@ RUN mkdir /data && \
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["valkey-server"]

--- a/8.1/alpine/Dockerfile
+++ b/8.1/alpine/Dockerfile
@@ -110,6 +110,8 @@ RUN set -eux; \
 		setpriv \
 		openssl \
 		libgcc \
+		# add tini to act as PID 1 and reap orphaned/zombie processes
+		tini \
 	;
 
 # Install valkey built earlier
@@ -125,7 +127,7 @@ RUN mkdir /data && \
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["valkey-server"]

--- a/8.1/debian/Dockerfile
+++ b/8.1/debian/Dockerfile
@@ -96,6 +96,8 @@ RUN set -eux; \
 # add tzdata explicitly for https://github.com/docker-library/redis/issues/138 (see also https://bugs.debian.org/837060 and related)
 		tzdata \
 		libssl3t64 \
+		# add tini to act as PID 1 and reap orphaned/zombie processes
+		tini \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -112,7 +114,7 @@ RUN mkdir /data && \
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["valkey-server"]

--- a/9.0/alpine/Dockerfile
+++ b/9.0/alpine/Dockerfile
@@ -110,6 +110,8 @@ RUN set -eux; \
 		setpriv \
 		openssl \
 		libgcc \
+		# add tini to act as PID 1 and reap orphaned/zombie processes
+		tini \
 	;
 
 # Install valkey built earlier
@@ -125,7 +127,7 @@ RUN mkdir /data && \
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["valkey-server"]

--- a/9.0/debian/Dockerfile
+++ b/9.0/debian/Dockerfile
@@ -96,6 +96,8 @@ RUN set -eux; \
 # add tzdata explicitly for https://github.com/docker-library/redis/issues/138 (see also https://bugs.debian.org/837060 and related)
 		tzdata \
 		libssl3t64 \
+		# add tini to act as PID 1 and reap orphaned/zombie processes
+		tini \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -112,7 +114,7 @@ RUN mkdir /data && \
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["valkey-server"]

--- a/9.1/alpine/Dockerfile
+++ b/9.1/alpine/Dockerfile
@@ -110,6 +110,8 @@ RUN set -eux; \
 		setpriv \
 		openssl \
 		libgcc \
+		# add tini to act as PID 1 and reap orphaned/zombie processes
+		tini \
 	;
 
 # Install valkey built earlier
@@ -125,7 +127,7 @@ RUN mkdir /data && \
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["valkey-server"]

--- a/9.1/debian/Dockerfile
+++ b/9.1/debian/Dockerfile
@@ -96,6 +96,8 @@ RUN set -eux; \
 # add tzdata explicitly for https://github.com/docker-library/redis/issues/138 (see also https://bugs.debian.org/837060 and related)
 		tzdata \
 		libssl3t64 \
+		# add tini to act as PID 1 and reap orphaned/zombie processes
+		tini \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -112,7 +114,7 @@ RUN mkdir /data && \
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["valkey-server"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -179,6 +179,8 @@ RUN set -eux; \
 		setpriv \
 		openssl \
 		libgcc \
+		# add tini to act as PID 1 and reap orphaned/zombie processes
+		tini \
 	;
 {{ ) else ( -}}
 RUN set -eux; \
@@ -187,6 +189,8 @@ RUN set -eux; \
 # add tzdata explicitly for https://github.com/docker-library/redis/issues/138 (see also https://bugs.debian.org/837060 and related)
 		tzdata \
 		{{ if .debian.version != "bookworm" then "libssl3t64" else "libssl3" end }} \
+		# add tini to act as PID 1 and reap orphaned/zombie processes
+		tini \
 	; \
 	rm -rf /var/lib/apt/lists/*
 {{ ) end -}}
@@ -204,7 +208,7 @@ RUN mkdir /data && \
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["valkey-server"]

--- a/unstable/alpine/Dockerfile
+++ b/unstable/alpine/Dockerfile
@@ -110,6 +110,8 @@ RUN set -eux; \
 		setpriv \
 		openssl \
 		libgcc \
+		# add tini to act as PID 1 and reap orphaned/zombie processes
+		tini \
 	;
 
 # Install valkey built earlier
@@ -125,7 +127,7 @@ RUN mkdir /data && \
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["valkey-server"]

--- a/unstable/debian/Dockerfile
+++ b/unstable/debian/Dockerfile
@@ -96,6 +96,8 @@ RUN set -eux; \
 # add tzdata explicitly for https://github.com/docker-library/redis/issues/138 (see also https://bugs.debian.org/837060 and related)
 		tzdata \
 		libssl3t64 \
+		# add tini to act as PID 1 and reap orphaned/zombie processes
+		tini \
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -112,7 +114,7 @@ RUN mkdir /data && \
 WORKDIR /data
 
 COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "docker-entrypoint.sh"]
 
 EXPOSE 6379
 CMD ["valkey-server"]


### PR DESCRIPTION
Fixes #149 

Valkey runs as PID 1 but only calls waitpid() during background operations (BGSAVE/AOF rewrite), so processes orphaned by external tooling (e.g. exec-based healthchecks/probes) can accumulate as zombies until the next background save.

This adds tini as a minimal init wrapper:

ENTRYPOINT ["tini", "--", "docker-entrypoint.sh"]

tini is installed via the existing package managers (apk/apt-get) in both base images. Since docker-entrypoint.sh already uses exec throughout, signal forwarding is unaffected - tini transparently reaps zombies without any entrypoint script changes.

Only Dockerfile.template was hand-edited; all per-version Dockerfiles were regenerated via apply-templates.sh.

Testing:
- Added .test/tests/valkey-tini to verify PID 1 is tini and that an orphaned process (simulated via a detached shell whose child outlives it) is reaped rather than left as a zombie.
- Verified the new test fails against the pre-change Dockerfile and passes against the updated one.